### PR TITLE
Add file slugs to Obs hydration results

### DIFF
--- a/smart_extract/tasks/obs.py
+++ b/smart_extract/tasks/obs.py
@@ -27,12 +27,13 @@ async def task_obs_members(
     stats = await hydrate_utils.process(
         client=client,
         task_name="obs-members",
-        desc="Downloading",
+        desc="Downloading member",
         workdir=workdir,
         source_dir=source_dir or workdir,
         input_type=resources.OBSERVATION,
         callback=_download_members,
         progress=progress,
+        file_slug="members",
     )
     if stats:
         stats.print("downloaded", f"{resources.OBSERVATION}s", "Members")
@@ -57,13 +58,14 @@ async def task_obs_dxr(
     stats = await hydrate_utils.process(
         client=client,
         task_name="dxr-results",
-        desc="Downloading",
+        desc="Downloading result",
         workdir=workdir,
         source_dir=source_dir or workdir,
         input_type=resources.DIAGNOSTIC_REPORT,
         output_type=resources.OBSERVATION,
         callback=_download_dxr_result,
         progress=progress,
+        file_slug="results",
     )
     if stats:
         stats.print(

--- a/tests/test_hydrate_obs.py
+++ b/tests/test_hydrate_obs.py
@@ -25,8 +25,8 @@ class HydrateObsMemberTests(utils.TestCase):
                     "version": utils.version,
                     "done": ["obs-members"],
                 },
-                f"{resources.OBSERVATION}.ndjson.gz": [
-                    *obs,
+                f"{resources.OBSERVATION}.ndjson.gz": obs,
+                f"{resources.OBSERVATION}.members.ndjson.gz": [
                     {"resourceType": resources.OBSERVATION, "id": "a1"},
                     {"resourceType": resources.OBSERVATION, "id": "a2"},
                     {"resourceType": resources.OBSERVATION, "id": "b"},
@@ -75,6 +75,8 @@ class HydrateObsMemberTests(utils.TestCase):
                         "id": "0",
                         "hasMember": [{"reference": "Observation/a"}],
                     },
+                ],
+                f"{resources.OBSERVATION}.members.ndjson.gz": [
                     {
                         "resourceType": resources.OBSERVATION,
                         "id": "a",
@@ -123,7 +125,7 @@ class HydrateObsDxrTests(utils.TestCase):
                     "done": ["dxr-results"],
                 },
                 f"{resources.DIAGNOSTIC_REPORT}.ndjson.gz": dxr,
-                f"{resources.OBSERVATION}.ndjson.gz": [
+                f"{resources.OBSERVATION}.results.ndjson.gz": [
                     {"resourceType": resources.OBSERVATION, "id": "a"},
                     {"resourceType": resources.OBSERVATION, "id": "b"},
                     {"resourceType": resources.OBSERVATION, "id": "c"},
@@ -152,7 +154,7 @@ class HydrateObsDxrTests(utils.TestCase):
                     f"{resources.DIAGNOSTIC_REPORT}.ndjson.gz": dxr,
                 },
                 ".metadata": None,
-                f"{resources.OBSERVATION}.ndjson.gz": [
+                f"{resources.OBSERVATION}.results.ndjson.gz": [
                     {"resourceType": resources.OBSERVATION, "id": "a"},
                 ],
             }

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,10 +19,12 @@ FROZEN_DATETIME = datetime.datetime(
 )
 FROZEN_TIMESTAMP = FROZEN_DATETIME.astimezone().isoformat()
 
+DEFAULT_OBS_CATEGORIES = (
+    "social-history,vital-signs,imaging,laboratory,survey,exam,procedure,therapy,activity"
+)
 DEFAULT_OBS_FILTER = (
-    f"{resources.OBSERVATION}?category=social-history,vital-signs,"
-    f"imaging,laboratory,survey,exam,procedure,therapy,activity"
-).replace(",", "%2C")
+    f"{resources.OBSERVATION}?category={DEFAULT_OBS_CATEGORIES.replace(",", "%2C")}"
+)
 
 version = smart_extract.__version__
 
@@ -65,7 +67,7 @@ class TestCase(unittest.IsolatedAsyncioTestCase):
 
     def set_resource_route(self, callback):
         route = self.server.get(
-            url__regex=rf"{self.url}/(?P<res_type>[^/]+)/(?P<res_id>[^/?]+)[^\$]*$"
+            url__regex=rf"{self.url}/(?P<res_type>[^/]+)/(?P<res_id>[^/?]+)[^/\$]*$"
         )
         route.side_effect = callback
 
@@ -91,14 +93,14 @@ class TestCase(unittest.IsolatedAsyncioTestCase):
                         "entry": [{"resource": resource} for resource in entries],
                     },
                 )
-            assert False, f"Invalid request: {request.url.params}"
+            assert False, f"Invalid request: {request}"
 
         self.set_resource_search_route(respond)
 
         return all_params
 
     def set_resource_search_route(self, callback):
-        route = self.server.get(url__regex=rf"{self.url}/(?P<res_type>[^/?]+)[^\$]*$")
+        route = self.server.get(url__regex=rf"{self.url}/(?P<res_type>[^/?]+)[^/\$]*$")
         route.side_effect = callback
 
     async def cli(self, *args) -> None:


### PR DESCRIPTION
This prevents colliding with the main Observation download file, and cleanly separates "hydration add ons" from "original export"