### PR TITLE
fix(export): always run cleanup steps even for finished resources

### DIFF
--- a/smart_extract/bulk_utils.py
+++ b/smart_extract/bulk_utils.py
@@ -741,21 +741,21 @@ async def perform_bulk(
             logging.info(f"Skipping {res_type}, already done.")
             already_done.add(res_type)
     res_types = set(filters) - already_done
-    if not res_types:
-        return
 
-    exporter = BulkExporter(
-        bulk_client,
-        res_types,
-        export_url(fhir_url, group),
-        workdir,
-        since=since,
-        type_filter=filters,
-        resume=resume,
-    )
-    await exporter.export()
+    if res_types:
+        exporter = BulkExporter(
+            bulk_client,
+            res_types,
+            export_url(fhir_url, group),
+            workdir,
+            since=since,
+            type_filter=filters,
+            resume=resume,
+        )
+        await exporter.export()
+        for res_type in res_types:
+            metadata.mark_done(res_type)
 
-    for res_type in res_types:
-        metadata.mark_done(res_type)
+    for res_type in filters:  # Run on all requested res types
         if finish_callback:
             await finish_callback(res_type)

--- a/smart_extract/cli/export.py
+++ b/smart_extract/cli/export.py
@@ -195,8 +195,6 @@ def make_links(workdir: str, res_type: str) -> None:
         os.symlink(target, os.path.join(source_dir, link_name))
 
     # Some resources have linked resources created by the hydration tasks
-    match res_type:
-        case resources.DIAGNOSTIC_REPORT:
-            make_links(workdir, resources.OBSERVATION)
-        case resources.MEDICATION_REQUEST:
-            make_links(workdir, resources.MEDICATION)
+    for input_type, output_type, task_func in tasks.all_tasks.values():
+        if res_type == input_type and res_type != output_type:
+            make_links(workdir, output_type)

--- a/smart_extract/lifecycle.py
+++ b/smart_extract/lifecycle.py
@@ -66,7 +66,7 @@ class OutputMetadata(Metadata):
 
     def mark_done(self, tag: str) -> None:
         if not self.is_done(tag):
-            self._contents.setdefault("done", []).append(tag)
+            self._contents["done"] = sorted([*self._contents.get("done", []), tag])
         self._write()
 
 

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -355,12 +355,13 @@ class CrawlTests(utils.TestCase):
         )
 
         # We would have errored out if any network attempts were made.
-        # Just confirm we also didn't write anything new out.
+        # Just confirm we only wrote out a new log.ndjson.
 
         self.assert_folder(
             {
                 ".metadata": {"done": [resources.DEVICE, resources.PATIENT]},
                 f"{resources.PATIENT}.ndjson.gz": None,
+                "log.ndjson": None,
             }
         )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,7 +23,7 @@ DEFAULT_OBS_CATEGORIES = (
     "social-history,vital-signs,imaging,laboratory,survey,exam,procedure,therapy,activity"
 )
 DEFAULT_OBS_FILTER = (
-    f"{resources.OBSERVATION}?category={DEFAULT_OBS_CATEGORIES.replace(",", "%2C")}"
+    f"{resources.OBSERVATION}?category={DEFAULT_OBS_CATEGORIES.replace(',', '%2C')}"
 )
 
 version = smart_extract.__version__


### PR DESCRIPTION
Before this change, if the user killed the app during a hydration task, when run again, the resource and all the hydration tasks for it would be skipped.

Now, just getting the resource again is skipped, and hydration tasks will have the option to run (or be skipped too).