### PR TITLE
feat: add --since=auto and rework workdir names

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ smart-extract export \
   /tmp/export
 
 ls -l /tmp/export
-# 238ec0e72fb1fd8dc9c4c0aa6a92459f/
-# Encounter.000.ndjson.gz -> 238ec0e72fb1fd8dc9c4c0aa6a92459f/Encounter.000.ndjson.gz
-# Patient.000.ndjson.gz -> 238ec0e72fb1fd8dc9c4c0aa6a92459f/Patient.000.ndjson.gz
+# 001.2025-06-26/
+# Encounter.001.ndjson.gz -> 001.2025-06-26/Encounter.001.ndjson.gz
+# Patient.001.ndjson.gz -> 001.2025-06-26/Patient.001.ndjson.gz
 
 # Second export with a --since date, a new resource, and a nickname for the export
 smart-extract export \
@@ -83,11 +83,11 @@ smart-extract export \
   /tmp/export
 
 ls -l /tmp/export
-# 238ec0e72fb1fd8dc9c4c0aa6a92459f/
-# second-run/
-# Condition.000.ndjson.gz -> second-run/Condition.000.ndjson.gz
-# Encounter.000.ndjson.gz -> 238ec0e72fb1fd8dc9c4c0aa6a92459f/Encounter.000.ndjson.gz
-# Encounter.001.ndjson.gz -> second-run/Encounter.000.ndjson.gz
-# Patient.000.ndjson.gz -> 238ec0e72fb1fd8dc9c4c0aa6a92459f/Patient.000.ndjson.gz
-# Patient.001.ndjson.gz -> second-run/Patient.000.ndjson.gz
+# 001.2025-06-26/
+# 002.second-run/
+# Condition.001.ndjson.gz -> 002.second-run/Condition.001.ndjson.gz
+# Encounter.001.ndjson.gz -> 001.2025-06-26/Encounter.001.ndjson.gz
+# Encounter.002.ndjson.gz -> 002.second-run/Encounter.001.ndjson.gz
+# Patient.001.ndjson.gz -> 001.2025-06-26/Patient.001.ndjson.gz
+# Patient.002.ndjson.gz -> 002.second-run/Patient.001.ndjson.gz
 ```

--- a/smart_extract/cli/crawl.py
+++ b/smart_extract/cli/crawl.py
@@ -42,13 +42,14 @@ async def crawl_main(args: argparse.Namespace) -> None:
         res_types = cli_utils.limit_to_server_resources(rest_client, res_types)
         filters = cli_utils.parse_type_filters(rest_client.server_type, res_types, args.type_filter)
         since_mode = cli_utils.calculate_since_mode(args.since_mode, rest_client.server_type)
-        filters = cli_utils.add_since_filter(filters, args.since, since_mode)
         workdir = args.folder
         source_dir = args.source_dir or workdir
 
         await crawl_utils.perform_crawl(
             fhir_url=args.fhir_url,
             filters=filters,
+            since=args.since,
+            since_mode=since_mode,
             source_dir=source_dir,
             workdir=workdir,
             rest_client=rest_client,

--- a/smart_extract/cli_utils.py
+++ b/smart_extract/cli_utils.py
@@ -61,7 +61,7 @@ def limit_to_server_resources(client: cfs.FhirClient, res_types: list[str]) -> l
     server_types = {res["type"] for res in rest["resource"] if "type" in res}
     for res_type in sorted(res_types):
         if res_type not in server_types:
-            logging.info(f"Skipping {res_type} because the server does not support it.")
+            logging.warning(f"Skipping {res_type} because the server does not support it.")
 
     return [x for x in res_types if x in server_types]
 
@@ -203,7 +203,7 @@ def add_cohort_selection(parser: argparse.ArgumentParser):
     )
     group.add_argument(
         "--group-nickname",
-        metavar="GROUP",
+        metavar="NAME",
         help="a human-friendly name for the cohort, used in log files and such",
     )
     group.add_argument("--mrn-system", metavar="SYSTEM", help="system identifier for MRNs")
@@ -233,7 +233,7 @@ def add_auth(parser: argparse.ArgumentParser):
     )
     group.add_argument(
         "--bulk-smart-key",
-        metavar="ID",
+        metavar="PATH",
         help="JWKS or PEM file for bulk export SMART authentication, "
         "only needed if your EHR uses separate bulk credentials",
     )

--- a/smart_extract/hydrate_utils.py
+++ b/smart_extract/hydrate_utils.py
@@ -170,14 +170,14 @@ async def process(
 
     metadata = lifecycle.OutputMetadata(workdir)
     if metadata.is_done(task_name):
-        logging.info(f"Skipping {task_name}, already done.")
+        logging.warning(f"Skipping {task_name}, already done.")
         return None
 
     # Calculate total progress needed
     found_files = cfs.list_multiline_json_in_dir(source_dir, input_type)
 
     if not found_files:
-        logging.info(f"Skipping {task_name}, no {input_type} resources found.")
+        logging.warning(f"Skipping {task_name}, no {input_type} resources found.")
         return None
 
     # See what is already present

--- a/smart_extract/iter_utils.py
+++ b/smart_extract/iter_utils.py
@@ -9,7 +9,7 @@ from typing import TypeVar
 import cumulus_fhir_support as cfs
 import rich.progress
 
-from smart_extract import cli_utils, ndjson
+from smart_extract import cli_utils, ndjson, timing
 
 Item = TypeVar("Item")
 
@@ -134,6 +134,7 @@ class ResourceProcessor:
             self._progress_task = self._progress.add_task(
                 f"{self._desc} {res_type}s…", total=res_total
             )
+            timestamp = timing.now()
 
             for source in sources:
                 writer = ndjson.NdjsonWriter(source.output_file, append=self._append)
@@ -147,7 +148,7 @@ class ResourceProcessor:
             if self._finish_callback:
                 # Note: might fire more than once for same res_type, if there are multiple
                 # sources. We can add some disambiguation in the future, if we need that.
-                await self._finish_callback(res_type, progress=self._progress)
+                await self._finish_callback(res_type, timestamp=timestamp, progress=self._progress)
 
         # Reset sources, so we can be run again
         self.sources = {}

--- a/smart_extract/lifecycle.py
+++ b/smart_extract/lifecycle.py
@@ -1,10 +1,11 @@
+import datetime
 import enum
 import json
 import os
 import sys
 
 import smart_extract
-from smart_extract import timing
+from smart_extract import cli_utils, timing
 
 
 class MetadataKind(enum.StrEnum):
@@ -21,13 +22,14 @@ class MetadataKind(enum.StrEnum):
 
 class Metadata:
     def __init__(self, folder: str, kind: MetadataKind):
-        self._path = os.path.join(folder, ".metadata")
+        self._folder = folder
+        self._path = os.path.join(self._folder, ".metadata")
         self._kind = kind
         self._contents = self._read()
         if found_kind := self._contents.get("kind"):
             if found_kind != self._kind:
                 sys.exit(
-                    f"Folder {folder} is not {MetadataKind.pretty(self._kind)},"
+                    f"Folder {self._folder} is not {MetadataKind.pretty(self._kind)},"
                     f" but {MetadataKind.pretty(found_kind)}"
                 )
 
@@ -47,7 +49,7 @@ class Metadata:
 
     def _write(self) -> None:
         self._contents.update(self._basic_metadata())
-        os.makedirs(os.path.dirname(self._path), exist_ok=True)
+        os.makedirs(self._folder, exist_ok=True)
 
         tmp_path = f"{self._path}.tmp"
         with open(tmp_path, "w", encoding="utf8") as f:
@@ -61,12 +63,110 @@ class OutputMetadata(Metadata):
     def __init__(self, folder: str):
         super().__init__(folder, MetadataKind.OUTPUT)
 
-    def is_done(self, tag: str) -> bool:
-        return tag in self._contents.get("done", [])
+    def note_context(
+        self, *, filters: cli_utils.Filters, since: str | None, since_mode: cli_utils.SinceMode
+    ) -> None:
+        ordered_filters = {res: sorted(params) for res, params in filters.items()}
+        if "filters" not in self._contents:
+            self._contents["filters"] = ordered_filters
+            self._contents["since"] = since
+            self._contents["sinceMode"] = str(since_mode) if since else None
+            self._write()
+            return
 
-    def mark_done(self, tag: str) -> None:
-        if not self.is_done(tag):
-            self._contents["done"] = sorted([*self._contents.get("done", []), tag])
+        found_filters = self._contents.get("filters")
+        if found_filters != ordered_filters:
+            sys.exit(
+                f"Folder {self._folder} is for a different set of types and/or filters. "
+                f"Expected:\n{self._pretty_filters(ordered_filters)}\n\nbut found:\n"
+                f"{self._pretty_filters(found_filters)}"
+            )
+
+        found_since = self._contents.get("since")
+        if found_since != since:
+            sys.exit(
+                f"Folder {self._folder} is for a different --since time. "
+                f"Expected {since} but found {found_since}."
+            )
+
+        found_since_mode = self._contents.get("sinceMode")
+        if since and found_since_mode != since_mode:
+            sys.exit(
+                f"Folder {self._folder} is for a different --since-mode. "
+                f"Expected '{since_mode}' but found '{found_since_mode}'."
+            )
+
+    def has_same_context(
+        self, *, filters: cli_utils.Filters, since: str | None, since_mode: cli_utils.SinceMode
+    ) -> bool:
+        """Determines if this folder is the same exact context (filters and since)"""
+        ordered_filters = {res: sorted(params) for res, params in filters.items()}
+        found_filters = self._contents.get("filters")
+        found_since = self._contents.get("since")
+        found_since_mode = self._contents.get("sinceMode")
+        return (
+            found_filters == ordered_filters
+            and found_since == since
+            and (not since or found_since_mode == since_mode)
+        )
+
+    def get_matching_timestamps(
+        self, filters: cli_utils.Filters, since_mode: str
+    ) -> dict[str, datetime.datetime]:
+        """
+        Tells if we have a superset of any resources from `filters`
+
+        Returns the resources that are a match, and that resource's finished timestamp.
+
+        This is used to find previous export timestamps to calculate a new automatic "since" value.
+        """
+        matches = {}
+
+        # We only match on the same type of "since"
+        if self._contents.get("sinceMode") and self._contents.get("sinceMode") != since_mode:
+            return matches
+
+        for res_type, params_list in self._contents.get("filters", {}).items():
+            if res_type not in filters:
+                continue
+
+            found_params = set(params_list)
+            both_empty = not filters[res_type] and not found_params
+            # We look for a subset here, because multiple type filters is an OR - so if we searched
+            # for A OR B before, but now are looking for previous A timestamps, that's a match.
+            target_is_subset = filters[res_type] and filters[res_type].issubset(found_params)
+            if both_empty or target_is_subset:
+                # OK this folder is a valid match for our current set of filters.
+                # Let's find the timestamps.
+                done = self._contents.get("done", {})
+                if res_type in done:
+                    matches[res_type] = datetime.datetime.fromisoformat(done[res_type])
+
+        return matches
+
+    @staticmethod
+    def _pretty_filters(filters: dict[str, list[str]]) -> str:
+        lines = []
+        for res_type, params_list in sorted(filters.items()):
+            if params_list:
+                lines.extend([f"  {res_type}?{params}" for params in params_list])
+            else:
+                lines.append(f"  {res_type} (no filter)")
+        return "\n".join(lines)
+
+    def is_done(self, tag: str) -> bool:
+        return tag in self._contents.get("done", {})
+
+    def mark_done(self, tag: str, timestamp: datetime.datetime | None = None) -> None:
+        """
+        Marks the given resource or task as done.
+
+        The timestamp is ideally a "transactionTime" style stamp (like in bulk export).
+        If not provided, it simply uses now().
+        """
+        timestamp = timestamp or timing.now()
+        done = self._contents.setdefault("done", {})
+        done[tag] = timestamp.isoformat()
         self._write()
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -6,8 +6,7 @@ from unittest import mock
 import ddt
 import httpx
 
-import smart_extract
-from smart_extract import lifecycle, resources, timing
+from smart_extract import cli_utils, lifecycle, resources
 from tests import utils
 
 
@@ -34,22 +33,20 @@ class ExportTests(utils.TestCase):
 
         self.assert_folder(
             {
-                "Condition.000.ndjson.gz": (
-                    "429c626ef720f128eadc5f68eabc00b9/Condition.000.ndjson.gz"
-                ),
-                "Patient.000.ndjson.gz": "429c626ef720f128eadc5f68eabc00b9/Patient.000.ndjson.gz",
-                "429c626ef720f128eadc5f68eabc00b9": {
+                "Condition.001.ndjson.gz": "001.2021-09-14/Condition.001.ndjson.gz",
+                "Patient.001.ndjson.gz": "001.2021-09-14/Patient.001.ndjson.gz",
+                "001.2021-09-14": {
                     ".metadata": None,
                     "log.ndjson": None,
-                    "Condition.000.ndjson.gz": [con1],
-                    "Patient.000.ndjson.gz": [pat1],
+                    "Condition.001.ndjson.gz": [con1],
+                    "Patient.001.ndjson.gz": [pat1],
                 },
                 ".metadata": {
                     "kind": "managed",
                     "fhir-url": "http://example.invalid/R4",
                     "group": "group1",
-                    "timestamp": timing.now().isoformat(),
-                    "version": smart_extract.__version__,
+                    "timestamp": utils.FROZEN_TIMESTAMP,
+                    "version": utils.version,
                 },
             }
         )
@@ -72,9 +69,9 @@ class ExportTests(utils.TestCase):
         self.assertEqual(missing, [])
         self.assert_folder(
             {
-                "Condition.000.ndjson.gz": None,
-                "Patient.000.ndjson.gz": None,
-                "429c626ef720f128eadc5f68eabc00b9": None,
+                "Condition.001.ndjson.gz": None,
+                "Patient.001.ndjson.gz": None,
+                "001.2021-09-14": None,
                 ".metadata": None,
             }
         )
@@ -103,9 +100,9 @@ class ExportTests(utils.TestCase):
         self.assertEqual(missing, [])
         self.assert_folder(
             {
-                "Condition.000.ndjson.gz": None,
-                "Patient.000.ndjson.gz": None,
-                "429c626ef720f128eadc5f68eabc00b9": None,
+                "Condition.001.ndjson.gz": None,
+                "Patient.001.ndjson.gz": None,
+                "001.2021-09-14": None,
                 ".metadata": None,
             }
         )
@@ -147,25 +144,21 @@ class ExportTests(utils.TestCase):
 
         self.assert_folder(
             {
-                "Encounter.000.ndjson.gz": (
-                    "238ec0e72fb1fd8dc9c4c0aa6a92459f/Encounter.000.ndjson.gz"
-                ),
-                "Encounter.001.ndjson.gz": (
-                    "47d55de8ca7736dab2337f20611b8b4d/Encounter.000.ndjson.gz"
-                ),
-                "Patient.000.ndjson.gz": "238ec0e72fb1fd8dc9c4c0aa6a92459f/Patient.000.ndjson.gz",
-                "Patient.001.ndjson.gz": "47d55de8ca7736dab2337f20611b8b4d/Patient.000.ndjson.gz",
-                "238ec0e72fb1fd8dc9c4c0aa6a92459f": {
+                "Encounter.001.ndjson.gz": "001.2021-09-14/Encounter.001.ndjson.gz",
+                "Encounter.002.ndjson.gz": "002.2021-09-14/Encounter.001.ndjson.gz",
+                "Patient.001.ndjson.gz": "001.2021-09-14/Patient.001.ndjson.gz",
+                "Patient.002.ndjson.gz": "002.2021-09-14/Patient.001.ndjson.gz",
+                "001.2021-09-14": {
                     ".metadata": None,
                     "log.ndjson": None,
-                    "Encounter.000.ndjson.gz": [enc1],
-                    "Patient.000.ndjson.gz": [pat1],
+                    "Encounter.001.ndjson.gz": [enc1],
+                    "Patient.001.ndjson.gz": [pat1],
                 },
-                "47d55de8ca7736dab2337f20611b8b4d": {
+                "002.2021-09-14": {
                     ".metadata": None,
                     "log.ndjson": None,
-                    "Encounter.000.ndjson.gz": [enc2],
-                    "Patient.000.ndjson.gz": [pat2],
+                    "Encounter.001.ndjson.gz": [enc2],
+                    "Patient.001.ndjson.gz": [pat2],
                 },
                 ".metadata": None,
             }
@@ -184,11 +177,11 @@ class ExportTests(utils.TestCase):
 
         self.assert_folder(
             {
-                "Patient.000.ndjson.gz": "my-export/Patient.000.ndjson.gz",
-                "my-export": {
+                "Patient.001.ndjson.gz": "001.my-export/Patient.001.ndjson.gz",
+                "001.my-export": {
                     ".metadata": None,
                     "log.ndjson": None,
-                    "Patient.000.ndjson.gz": [pat1],
+                    "Patient.001.ndjson.gz": [pat1],
                 },
                 ".metadata": None,
             }
@@ -218,10 +211,10 @@ class ExportTests(utils.TestCase):
         self.assertEqual(missing, [])
         self.assert_folder(
             {
-                "Condition.000.ndjson.gz": "c0364eeb431653e28217058258792f8b/Condition.ndjson.gz",
-                "Patient.000.ndjson.gz": "6fd669b7904f3e1e63674456c6b2bac8/Patient.000.ndjson.gz",
-                "6fd669b7904f3e1e63674456c6b2bac8": None,
-                "c0364eeb431653e28217058258792f8b": None,
+                "Condition.001.ndjson.gz": "002.2021-09-14/Condition.ndjson.gz",
+                "Patient.001.ndjson.gz": "001.2021-09-14/Patient.001.ndjson.gz",
+                "001.2021-09-14": None,
+                "002.2021-09-14": None,
                 ".metadata": None,
             }
         )
@@ -249,17 +242,15 @@ class ExportTests(utils.TestCase):
 
         self.assert_folder(
             {
-                "Medication.000.ndjson.gz": "2833a8e392566c339ab7a1d3096759ac/Medication.ndjson.gz",
-                "MedicationRequest.000.ndjson.gz": (
-                    "2833a8e392566c339ab7a1d3096759ac/MedicationRequest.000.ndjson.gz"
-                ),
-                "Patient.000.ndjson.gz": "2833a8e392566c339ab7a1d3096759ac/Patient.000.ndjson.gz",
-                "2833a8e392566c339ab7a1d3096759ac": {
+                "Medication.001.ndjson.gz": "001.2021-09-14/Medication.ndjson.gz",
+                "MedicationRequest.001.ndjson.gz": "001.2021-09-14/MedicationRequest.001.ndjson.gz",
+                "Patient.001.ndjson.gz": "001.2021-09-14/Patient.001.ndjson.gz",
+                "001.2021-09-14": {
                     ".metadata": None,
                     "log.ndjson": None,
                     "Medication.ndjson.gz": [{"resourceType": resources.MEDICATION, "id": "1"}],
-                    "MedicationRequest.000.ndjson.gz": None,
-                    "Patient.000.ndjson.gz": None,
+                    "MedicationRequest.001.ndjson.gz": None,
+                    "Patient.001.ndjson.gz": None,
                 },
                 ".metadata": None,
             }
@@ -294,25 +285,19 @@ class ExportTests(utils.TestCase):
 
         self.assert_folder(
             {
-                "DiagnosticReport.000.ndjson.gz": (
-                    "51c899230c8523059734d6c168ea5971/DiagnosticReport.000.ndjson.gz"
-                ),
-                "Observation.000.ndjson.gz": (
-                    "51c899230c8523059734d6c168ea5971/Observation.000.ndjson.gz"
-                ),
-                "Observation.001.ndjson.gz": (
-                    "51c899230c8523059734d6c168ea5971/Observation.results.ndjson.gz"
-                ),
-                "Patient.000.ndjson.gz": "51c899230c8523059734d6c168ea5971/Patient.000.ndjson.gz",
-                "51c899230c8523059734d6c168ea5971": {
+                "DiagnosticReport.001.ndjson.gz": "001.2021-09-14/DiagnosticReport.001.ndjson.gz",
+                "Observation.001.ndjson.gz": "001.2021-09-14/Observation.001.ndjson.gz",
+                "Observation.002.ndjson.gz": "001.2021-09-14/Observation.results.ndjson.gz",
+                "Patient.001.ndjson.gz": "001.2021-09-14/Patient.001.ndjson.gz",
+                "001.2021-09-14": {
                     ".metadata": None,
                     "log.ndjson": None,
-                    "DiagnosticReport.000.ndjson.gz": [dxr1],
+                    "DiagnosticReport.001.ndjson.gz": [dxr1],
                     "Observation.results.ndjson.gz": [
                         {"resourceType": resources.OBSERVATION, "id": "obs2"},
                     ],
-                    "Observation.000.ndjson.gz": [obs1],
-                    "Patient.000.ndjson.gz": [pat1],
+                    "Observation.001.ndjson.gz": [obs1],
+                    "Patient.001.ndjson.gz": [pat1],
                 },
                 ".metadata": None,
             }
@@ -366,20 +351,12 @@ class ExportTests(utils.TestCase):
         self.assertEqual(missing, [])
         self.assert_folder(
             {
-                "DiagnosticReport.000.ndjson.gz": (
-                    "51c899230c8523059734d6c168ea5971/DiagnosticReport.ndjson.gz"
-                ),
-                "Observation.000.ndjson.gz": (
-                    "51c899230c8523059734d6c168ea5971/Observation.members.ndjson.gz"
-                ),
-                "Observation.001.ndjson.gz": (
-                    "51c899230c8523059734d6c168ea5971/Observation.results.ndjson.gz"
-                ),
-                "Observation.002.ndjson.gz": (
-                    "51c899230c8523059734d6c168ea5971/Observation.ndjson.gz"
-                ),
-                "Patient.000.ndjson.gz": "51c899230c8523059734d6c168ea5971/Patient.000.ndjson.gz",
-                "51c899230c8523059734d6c168ea5971": {
+                "DiagnosticReport.001.ndjson.gz": "001.2021-09-14/DiagnosticReport.ndjson.gz",
+                "Observation.001.ndjson.gz": "001.2021-09-14/Observation.members.ndjson.gz",
+                "Observation.002.ndjson.gz": "001.2021-09-14/Observation.results.ndjson.gz",
+                "Observation.003.ndjson.gz": "001.2021-09-14/Observation.ndjson.gz",
+                "Patient.001.ndjson.gz": "001.2021-09-14/Patient.001.ndjson.gz",
+                "001.2021-09-14": {
                     ".metadata": None,
                     "log.ndjson": None,
                     "DiagnosticReport.ndjson.gz": [dxr1],
@@ -389,7 +366,7 @@ class ExportTests(utils.TestCase):
                         {"resourceType": resources.OBSERVATION, "id": "res-obs.member"},
                     ],
                     "Observation.results.ndjson.gz": [res_obs],
-                    "Patient.000.ndjson.gz": [pat1],
+                    "Patient.001.ndjson.gz": [pat1],
                 },
                 ".metadata": None,
             }
@@ -437,20 +414,14 @@ class ExportTests(utils.TestCase):
 
         self.assert_folder(
             {
-                "DiagnosticReport.000.ndjson.gz": (
-                    "2ad4e53a236e44752ccc301537e74320/DiagnosticReport.000.ndjson.gz"
-                ),
-                "Observation.000.ndjson.gz": (
-                    "2ad4e53a236e44752ccc301537e74320/Observation.members.ndjson.gz"
-                ),
-                "Observation.001.ndjson.gz": (
-                    "2ad4e53a236e44752ccc301537e74320/Observation.results.ndjson.gz"
-                ),
-                "Patient.000.ndjson.gz": "2ad4e53a236e44752ccc301537e74320/Patient.000.ndjson.gz",
-                "2ad4e53a236e44752ccc301537e74320": {
+                "DiagnosticReport.001.ndjson.gz": "001.2021-09-14/DiagnosticReport.001.ndjson.gz",
+                "Observation.001.ndjson.gz": "001.2021-09-14/Observation.members.ndjson.gz",
+                "Observation.002.ndjson.gz": "001.2021-09-14/Observation.results.ndjson.gz",
+                "Patient.001.ndjson.gz": "001.2021-09-14/Patient.001.ndjson.gz",
+                "001.2021-09-14": {
                     ".metadata": None,
                     "log.ndjson": None,
-                    "DiagnosticReport.000.ndjson.gz": [dxr1],
+                    "DiagnosticReport.001.ndjson.gz": [dxr1],
                     "Observation.members.ndjson.gz": [
                         {"resourceType": resources.OBSERVATION, "id": "obs2"},
                     ],
@@ -461,7 +432,7 @@ class ExportTests(utils.TestCase):
                             "hasMember": [{"reference": "Observation/obs2"}],
                         },
                     ],
-                    "Patient.000.ndjson.gz": [pat1],
+                    "Patient.001.ndjson.gz": [pat1],
                 },
                 ".metadata": None,
             }
@@ -480,32 +451,36 @@ class ExportTests(utils.TestCase):
             await self.cli("export", self.folder, "--group=new-group")
 
     async def test_random_resource_file_is_ignored(self):
-        os.makedirs(f"{self.folder}/6fe4dc54280b62bf8992843f2bd9a544")
+        """Confirm that when making links, we don't link *everything*"""
+        # First, make an existing workdir to resume, so we can stuff some random files in there
+        workdir = f"{self.folder}/001.2021-09-14"
+        os.makedirs(workdir)
+
+        metadata = lifecycle.OutputMetadata(workdir)
+        metadata.note_context(
+            filters={resources.PATIENT: set()}, since=None, since_mode=cli_utils.SinceMode.UPDATED
+        )
 
         # Non gzipped is ignored
-        with open(
-            f"{self.folder}/6fe4dc54280b62bf8992843f2bd9a544/test.ndjson", "w", encoding="utf8"
-        ) as f:
+        with open(f"{workdir}/test.ndjson", "w", encoding="utf8") as f:
             json.dump({"resourceType": resources.PATIENT, "id": "pat1"}, f)
 
         # Gzipped is assumed to be ours
-        with gzip.open(
-            f"{self.folder}/6fe4dc54280b62bf8992843f2bd9a544/test.ndjson.gz", "wt", encoding="utf8"
-        ) as f:
+        with gzip.open(f"{workdir}/test.ndjson.gz", "wt", encoding="utf8") as f:
             json.dump({"resourceType": resources.PATIENT, "id": "pat1"}, f)
 
         self.mock_bulk("group1")
-        await self.cli("export", self.folder, "--group=group1")
+        await self.cli("export", self.folder, "--group=group1", "--type", resources.PATIENT)
 
         self.assert_folder(
             {
-                "6fe4dc54280b62bf8992843f2bd9a544": {
+                "001.2021-09-14": {
                     ".metadata": None,
                     "log.ndjson": None,
                     "test.ndjson": None,
                     "test.ndjson.gz": None,
                 },
-                "Patient.000.ndjson.gz": "6fe4dc54280b62bf8992843f2bd9a544/test.ndjson.gz",
+                "Patient.001.ndjson.gz": "001.2021-09-14/test.ndjson.gz",
                 ".metadata": None,
             }
         )
@@ -543,12 +518,15 @@ class ExportTests(utils.TestCase):
         self.set_resource_route(respond)
 
         mocker = mock.patch("smart_extract.hydrate_utils.process", side_effect=RuntimeError)
+        self.addCleanup(mocker.stop)
         mocker.start()
 
         if export_mode == "crawl":
             suffix = "ndjson.gz"
+            res_time = utils.FROZEN_TIMESTAMP
         else:
-            suffix = "000.ndjson.gz"
+            suffix = "001.ndjson.gz"
+            res_time = utils.TRANSACTION_TIME
 
         # First interrupted run
         with self.assertRaises(RuntimeError):
@@ -561,20 +539,24 @@ class ExportTests(utils.TestCase):
             )
         self.assert_folder(
             {
-                "f15b547993ad1394372c61c030da3b11": {
+                "001.2021-09-14": {
                     ".metadata": {
-                        "done": [resources.DOCUMENT_REFERENCE, resources.PATIENT],
+                        "done": {
+                            resources.DOCUMENT_REFERENCE: res_time,
+                            resources.PATIENT: utils.TRANSACTION_TIME,
+                        },
+                        "filters": {resources.DOCUMENT_REFERENCE: [], resources.PATIENT: []},
+                        "since": None,
+                        "sinceMode": None,
                         "kind": "output",
                         "timestamp": utils.FROZEN_TIMESTAMP,
                         "version": utils.version,
                     },
                     "log.ndjson": None,
-                    f"{resources.PATIENT}.000.ndjson.gz": [pat1],
+                    f"{resources.PATIENT}.001.ndjson.gz": [pat1],
                     f"{resources.DOCUMENT_REFERENCE}.{suffix}": [doc1],
                 },
-                "Patient.000.ndjson.gz": (
-                    f"f15b547993ad1394372c61c030da3b11/{resources.PATIENT}.000.ndjson.gz"
-                ),
+                "Patient.001.ndjson.gz": f"001.2021-09-14/{resources.PATIENT}.001.ndjson.gz",
                 ".metadata": None,
             }
         )
@@ -590,15 +572,22 @@ class ExportTests(utils.TestCase):
         )
         self.assert_folder(
             {
-                "f15b547993ad1394372c61c030da3b11": {
+                "001.2021-09-14": {
                     ".metadata": {
-                        "done": [resources.DOCUMENT_REFERENCE, resources.PATIENT, "doc-inline"],
+                        "done": {
+                            resources.DOCUMENT_REFERENCE: res_time,
+                            resources.PATIENT: utils.TRANSACTION_TIME,
+                            "doc-inline": utils.FROZEN_TIMESTAMP,
+                        },
+                        "filters": {resources.DOCUMENT_REFERENCE: [], resources.PATIENT: []},
+                        "since": None,
+                        "sinceMode": None,
                         "kind": "output",
                         "timestamp": utils.FROZEN_TIMESTAMP,
                         "version": utils.version,
                     },
                     "log.ndjson": None,
-                    f"{resources.PATIENT}.000.ndjson.gz": [pat1],
+                    f"{resources.PATIENT}.001.ndjson.gz": [pat1],
                     f"{resources.DOCUMENT_REFERENCE}.{suffix}": [
                         {
                             "resourceType": resources.DOCUMENT_REFERENCE,
@@ -617,12 +606,366 @@ class ExportTests(utils.TestCase):
                         }
                     ],
                 },
-                f"{resources.DOCUMENT_REFERENCE}.000.ndjson.gz": (
-                    f"f15b547993ad1394372c61c030da3b11/{resources.DOCUMENT_REFERENCE}.{suffix}"
+                f"{resources.DOCUMENT_REFERENCE}.001.ndjson.gz": (
+                    f"001.2021-09-14/{resources.DOCUMENT_REFERENCE}.{suffix}"
                 ),
-                f"{resources.PATIENT}.000.ndjson.gz": (
-                    f"f15b547993ad1394372c61c030da3b11/{resources.PATIENT}.000.ndjson.gz"
+                f"{resources.PATIENT}.001.ndjson.gz": (
+                    f"001.2021-09-14/{resources.PATIENT}.001.ndjson.gz"
                 ),
                 ".metadata": None,
+            }
+        )
+
+    async def test_finds_prev_workdir_to_resume(self):
+        """Confirm we grab the right old folder to resume"""
+        # Make all exports fail until further notice
+        mocker = mock.patch(
+            "smart_extract.bulk_utils.BulkExporter.export", side_effect=RuntimeError
+        )
+        self.addCleanup(mocker.stop)
+        mocker.start()
+
+        # Make lots of interrupted exports with different configs
+        with self.assertRaises(RuntimeError):
+            await self.cli("export", self.folder, f"--type={resources.CONDITION}")
+        with self.assertRaises(RuntimeError):
+            await self.cli(
+                "export", self.folder, f"--type={resources.CONDITION},{resources.DEVICE}"
+            )
+        with self.assertRaises(RuntimeError):
+            await self.cli(
+                "export", self.folder, f"--type={resources.CONDITION}", "--since=2020-10-10"
+            )
+        with self.assertRaises(RuntimeError):
+            await self.cli(
+                "export",
+                self.folder,
+                f"--type={resources.CONDITION}",
+                f"--type-filter={resources.CONDITION}?code=1234",
+            )
+        with self.assertRaises(RuntimeError):
+            await self.cli(
+                "export",
+                self.folder,
+                f"--type={resources.CONDITION}",
+                "--since=2020-10-10",
+                f"--type-filter={resources.CONDITION}?code=1234",
+            )
+
+        self.assert_folder(
+            {
+                "001.2021-09-14": {".metadata": None},
+                "002.2021-09-14": {".metadata": None},
+                "003.2021-09-14": {".metadata": None},
+                "004.2021-09-14": {".metadata": None},
+                "005.2021-09-14": {".metadata": None},
+                ".metadata": None,
+            }
+        )
+
+        # OK let's allow bulk again - let's mock all the options
+        mocker.stop()
+
+        con1 = {"resourceType": resources.CONDITION, "id": "con1"}
+        con2 = {"resourceType": resources.CONDITION, "id": "con2"}
+        con3 = {"resourceType": resources.CONDITION, "id": "con3"}
+        con4 = {"resourceType": resources.CONDITION, "id": "con4"}
+        con5 = {"resourceType": resources.CONDITION, "id": "con5"}
+        dev1 = {"resourceType": resources.DEVICE, "id": "dev1"}
+        self.mock_bulk(output=[dev1], params={"_type": resources.DEVICE})
+        self.mock_bulk(output=[con1], params={"_type": resources.CONDITION})
+        self.mock_bulk(output=[con2], params={"_type": f"{resources.CONDITION},{resources.DEVICE}"})
+        self.mock_bulk(output=[con3], params={"_type": resources.CONDITION, "_since": "2020-10-10"})
+        self.mock_bulk(
+            output=[con4],
+            params={
+                "_type": resources.CONDITION,
+                "_typeFilter": f"{resources.CONDITION}?code=1234",
+            },
+        )
+        self.mock_bulk(
+            output=[con5],
+            params={
+                "_type": resources.CONDITION,
+                "_typeFilter": f"{resources.CONDITION}?code=1234",
+                "_since": "2020-10-10",
+            },
+        )
+
+        # Now do all the same requests as before, which should resume each one (in mixed up order)
+        await self.cli("export", self.folder, f"--type={resources.CONDITION}", "--since=2020-10-10")
+        await self.cli("export", self.folder, f"--type={resources.CONDITION}")
+        await self.cli(
+            "export",
+            self.folder,
+            f"--type={resources.CONDITION}",
+            "--since=2020-10-10",
+            f"--type-filter={resources.CONDITION}?code=1234",
+        )
+        await self.cli("export", self.folder, f"--type={resources.CONDITION},{resources.DEVICE}")
+        await self.cli(
+            "export",
+            self.folder,
+            f"--type={resources.CONDITION}",
+            f"--type-filter={resources.CONDITION}?code=1234",
+        )
+
+        # This is a new one
+        await self.cli("export", self.folder, f"--type={resources.DEVICE}")
+
+        self.assert_folder(
+            {
+                "001.2021-09-14": {
+                    ".metadata": None,
+                    "log.ndjson": None,
+                    f"{resources.CONDITION}.001.ndjson.gz": [con1],
+                },
+                "002.2021-09-14": {
+                    ".metadata": None,
+                    "log.ndjson": None,
+                    f"{resources.CONDITION}.001.ndjson.gz": [con2],
+                },
+                "003.2021-09-14": {
+                    ".metadata": None,
+                    "log.ndjson": None,
+                    f"{resources.CONDITION}.001.ndjson.gz": [con3],
+                },
+                "004.2021-09-14": {
+                    ".metadata": None,
+                    "log.ndjson": None,
+                    f"{resources.CONDITION}.001.ndjson.gz": [con4],
+                },
+                "005.2021-09-14": {
+                    ".metadata": None,
+                    "log.ndjson": None,
+                    f"{resources.CONDITION}.001.ndjson.gz": [con5],
+                },
+                "006.2021-09-14": {
+                    ".metadata": None,
+                    "log.ndjson": None,
+                    f"{resources.DEVICE}.001.ndjson.gz": [dev1],
+                },
+                ".metadata": None,
+                "Condition.001.ndjson.gz": "003.2021-09-14/Condition.001.ndjson.gz",
+                "Condition.002.ndjson.gz": "001.2021-09-14/Condition.001.ndjson.gz",
+                "Condition.003.ndjson.gz": "005.2021-09-14/Condition.001.ndjson.gz",
+                "Condition.004.ndjson.gz": "002.2021-09-14/Condition.001.ndjson.gz",
+                "Condition.005.ndjson.gz": "004.2021-09-14/Condition.001.ndjson.gz",
+                "Device.001.ndjson.gz": "006.2021-09-14/Device.001.ndjson.gz",
+            }
+        )
+
+    async def test_finds_prev_workdir_to_resume_with_nicknames(self):
+        """Confirm we grab the right old folder to resume when using nicknames"""
+        # Make all exports fail until further notice
+        mocker = mock.patch(
+            "smart_extract.bulk_utils.BulkExporter.export", side_effect=RuntimeError
+        )
+        self.addCleanup(mocker.stop)
+        mocker.start()
+
+        # Make an interrupted export
+        with self.assertRaises(RuntimeError):
+            await self.cli("export", self.folder, "--type=Condition", "--nickname=test")
+
+        self.assert_folder(
+            {
+                "001.test": {".metadata": None},
+                ".metadata": None,
+            }
+        )
+
+        # OK let's allow bulk again
+        mocker.stop()
+        self.mock_bulk()
+
+        # First confirm that if we use the same nickname but with a different set of filters,
+        # we correctly error out.
+        with self.assertRaisesRegex(SystemExit, "is for a different set of types and/or filters"):
+            await self.cli("export", self.folder, f"--type={resources.DEVICE}", "--nickname=test")
+
+        # Actually resume the export.
+        await self.cli("export", self.folder, f"--type={resources.CONDITION}", "--nickname=test")
+
+        self.assert_folder(
+            {
+                "001.test": {
+                    ".metadata": None,
+                    "log.ndjson": None,  # indicates we finished
+                },
+                ".metadata": None,
+            }
+        )
+
+    async def test_since_auto(self):
+        """Confirm we calculate the right "since" value for since=auto"""
+        # Do some initial (empty) exports, marking each with a different transaction time.
+        self.mock_bulk(
+            params={"_type": f"{resources.CONDITION},{resources.ENCOUNTER}"},
+            transaction_time="2001-01-01",
+        )
+        await self.cli("export", self.folder, f"--type={resources.CONDITION},{resources.ENCOUNTER}")
+
+        self.mock_bulk(
+            params={
+                "_type": resources.CONDITION,
+                "_typeFilter": f"{resources.CONDITION}?code=1234",
+            },
+            transaction_time="2002-02-02",
+        )
+        await self.cli(
+            "export",
+            self.folder,
+            f"--type={resources.CONDITION}",
+            f"--type-filter={resources.CONDITION}?code=1234",
+        )
+
+        self.mock_bulk(
+            params={
+                "_type": resources.CONDITION,
+                "_typeFilter": f"{resources.CONDITION}?code=1234,{resources.CONDITION}?code=5678",
+            },
+            transaction_time="2003-03-03",
+        )
+        await self.cli(
+            "export",
+            self.folder,
+            f"--type={resources.CONDITION}",
+            f"--type-filter={resources.CONDITION}?code=1234",
+            f"--type-filter={resources.CONDITION}?code=5678",
+        )
+
+        # Now... Run some --since=auto exports, and we should be seeing the right since values.
+
+        # First one is for code 1234 which will base off the 3rd example above (because that was
+        # an "OR" search, it's a valid match).
+        self.mock_bulk(
+            params={
+                "_type": resources.CONDITION,
+                "_since": "2003-03-03T00:00:00",
+                "_typeFilter": f"{resources.CONDITION}?code=1234",
+            },
+        )
+        await self.cli(
+            "export",
+            self.folder,
+            f"--type={resources.CONDITION}",
+            f"--type-filter={resources.CONDITION}?code=1234",
+            "--since=auto",
+        )
+
+        # Same thing for 5678
+        self.mock_bulk(
+            params={
+                "_type": resources.CONDITION,
+                "_since": "2003-03-03T00:00:00",
+                "_typeFilter": f"{resources.CONDITION}?code=5678",
+            },
+        )
+        await self.cli(
+            "export",
+            self.folder,
+            f"--type={resources.CONDITION}",
+            f"--type-filter={resources.CONDITION}?code=5678",
+            "--since=auto",
+        )
+
+        # And try an unfiltered search, which should be based off the 1st export above.
+        self.mock_bulk(
+            params={"_type": resources.CONDITION, "_since": "2001-01-01T00:00:00"},
+            transaction_time="2004-04-04",
+        )
+        await self.cli("export", self.folder, f"--type={resources.CONDITION}", "--since=auto")
+
+        # And ANOTHER unfiltered search, which should be based off the export right above.
+        self.mock_bulk(params={"_type": resources.CONDITION, "_since": "2004-04-04T00:00:00"})
+        await self.cli("export", self.folder, f"--type={resources.CONDITION}", "--since=auto")
+
+        # And ANOTHER unfiltered search, with a different mode. Should go back to first search.
+        self.mock_bulk(
+            params={
+                "_type": resources.CONDITION,
+                "_typeFilter": "Condition?recorded-date=gt2001-01-01T00:00:00",
+            }
+        )
+        await self.cli(
+            "export",
+            self.folder,
+            f"--type={resources.CONDITION}",
+            "--since=auto",
+            "--since-mode=created",
+            "--nickname=created-mode",
+        )
+
+        self.assert_folder(
+            {
+                "001.2021-09-14": {
+                    ".metadata": None,
+                    "log.ndjson": None,
+                },
+                "002.2021-09-14": {
+                    ".metadata": None,
+                    "log.ndjson": None,
+                },
+                "003.2021-09-14": {
+                    ".metadata": None,
+                    "log.ndjson": None,
+                },
+                "004.2021-09-14": {
+                    ".metadata": None,
+                    "log.ndjson": None,
+                },
+                "005.2021-09-14": {
+                    ".metadata": None,
+                    "log.ndjson": None,
+                },
+                "006.2021-09-14": {
+                    # Just sample one of these metadata files, to confirm we record the "since" date
+                    ".metadata": {
+                        "done": {resources.CONDITION: "2004-04-04T00:00:00"},
+                        "filters": {resources.CONDITION: []},
+                        "since": "2001-01-01T00:00:00",
+                        "sinceMode": "updated",
+                        "kind": "output",
+                        "timestamp": utils.FROZEN_TIMESTAMP,
+                        "version": utils.version,
+                    },
+                    "log.ndjson": None,
+                },
+                "007.2021-09-14": {
+                    ".metadata": None,
+                    "log.ndjson": None,
+                },
+                "008.created-mode": {
+                    # Confirm we went back to the original export when using a new mode
+                    ".metadata": {
+                        "done": {resources.CONDITION: utils.TRANSACTION_TIME},
+                        "filters": {resources.CONDITION: []},
+                        "since": "2001-01-01T00:00:00",
+                        "sinceMode": "created",
+                        "kind": "output",
+                        "timestamp": utils.FROZEN_TIMESTAMP,
+                        "version": utils.version,
+                    },
+                    "log.ndjson": None,
+                },
+                ".metadata": None,
+            }
+        )
+
+    async def test_since_auto_not_found(self):
+        """Confirm bail if we can't find a previous since target"""
+        with self.assertRaisesRegex(SystemExit, "Could not detect a since value to use"):
+            await self.cli("export", self.folder, f"--type={resources.CONDITION}", "--since=auto")
+
+    async def test_pointing_at_empty_dir(self):
+        self.mock_bulk()
+        await self.cli("export", self.folder / "nope", f"--type={resources.CONDITION}")
+        self.assert_folder(
+            {
+                "nope": {
+                    "001.2021-09-14": None,
+                    ".metadata": None,
+                },
             }
         )

--- a/tests/test_hydrate.py
+++ b/tests/test_hydrate.py
@@ -110,7 +110,7 @@ class HydrateTests(utils.TestCase):
                     "kind": "output",
                     "timestamp": utils.FROZEN_TIMESTAMP,
                     "version": utils.version,
-                    "done": ["meds"],
+                    "done": {"meds": utils.FROZEN_TIMESTAMP},
                 },
                 f"{resources.MEDICATION_REQUEST}.ndjson.gz": None,
             }

--- a/tests/test_hydrate_meds.py
+++ b/tests/test_hydrate_meds.py
@@ -19,7 +19,7 @@ class HydrateMedsTests(utils.TestCase):
                     "kind": "output",
                     "timestamp": utils.FROZEN_TIMESTAMP,
                     "version": utils.version,
-                    "done": ["meds"],
+                    "done": {"meds": utils.FROZEN_TIMESTAMP},
                 },
                 f"{resources.MEDICATION}.ndjson.gz": [
                     {"resourceType": resources.MEDICATION, "id": "1"},

--- a/tests/test_hydrate_obs.py
+++ b/tests/test_hydrate_obs.py
@@ -23,7 +23,7 @@ class HydrateObsMemberTests(utils.TestCase):
                     "kind": "output",
                     "timestamp": utils.FROZEN_TIMESTAMP,
                     "version": utils.version,
-                    "done": ["obs-members"],
+                    "done": {"obs-members": utils.FROZEN_TIMESTAMP},
                 },
                 f"{resources.OBSERVATION}.ndjson.gz": obs,
                 f"{resources.OBSERVATION}.members.ndjson.gz": [
@@ -122,7 +122,7 @@ class HydrateObsDxrTests(utils.TestCase):
                     "kind": "output",
                     "timestamp": utils.FROZEN_TIMESTAMP,
                     "version": utils.version,
-                    "done": ["dxr-results"],
+                    "done": {"dxr-results": utils.FROZEN_TIMESTAMP},
                 },
                 f"{resources.DIAGNOSTIC_REPORT}.ndjson.gz": dxr,
                 f"{resources.OBSERVATION}.results.ndjson.gz": [


### PR DESCRIPTION
- Use workdir names like {num}.{nickname} (nickname defaults to the current day)
- Write more info into metadata files, like since and filter info
- Allow --since=auto to search back through folders and find a suitable since value
- Unrelatedly, start counting files from 001 instead of 000


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
