### PR TITLE
fix: use an older transaction time if the server provides stale data

### DIFF
--- a/smart_fetch/bulk_utils.py
+++ b/smart_fetch/bulk_utils.py
@@ -446,7 +446,7 @@ class BulkExporter:
         response_json = response.json()
 
         try:
-            raw_transaction_time = response_json.get("transactionTime")
+            raw_transaction_time = response_json.get("transactionTime")  # "instant" type
             self.transaction_time = datetime.datetime.fromisoformat(raw_transaction_time)
         except ValueError as exc:
             logging.error(f"Could not parse transactionTime: {exc}")

--- a/smart_fetch/cli/bulk.py
+++ b/smart_fetch/cli/bulk.py
@@ -69,4 +69,3 @@ async def cancel_bulk(bulk_client: cfs.FhirClient, resume_url: str | None) -> No
     async with bulk_client:
         exporter = bulk_utils.BulkExporter(bulk_client, set(), "", "", resume=resume_url)
         await exporter.cancel()
-        logging.warning("Export cancelled.")

--- a/smart_fetch/cli/crawl.py
+++ b/smart_fetch/cli/crawl.py
@@ -15,7 +15,8 @@ def make_subparser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--since-mode",
         choices=list(cli_utils.SinceMode),
-        help="how to interpret --since",
+        default=cli_utils.SinceMode.AUTO,
+        help="how to interpret --since (defaults to 'updated' if server supports it)",
     )
 
     group = cli_utils.add_cohort_selection(parser)
@@ -41,7 +42,9 @@ async def crawl_main(args: argparse.Namespace) -> None:
     async with rest_client:
         res_types = cli_utils.limit_to_server_resources(rest_client, res_types)
         filters = cli_utils.parse_type_filters(rest_client.server_type, res_types, args.type_filter)
-        since_mode = cli_utils.calculate_since_mode(args.since_mode, rest_client.server_type)
+        since_mode = cli_utils.calculate_since_mode(
+            args.since, args.since_mode, rest_client.server_type
+        )
         workdir = args.folder
         source_dir = args.source_dir or workdir
 

--- a/smart_fetch/cli/main.py
+++ b/smart_fetch/cli/main.py
@@ -38,6 +38,8 @@ async def main(argv: list[str]) -> None:
     args = parser.parse_args(argv)
     await args.func(args)
 
+    rich.get_console().print("✨ Done ✨")
+
 
 def main_cli():
     asyncio.run(main(sys.argv[1:]))  # pragma: no cover

--- a/smart_fetch/cli_utils.py
+++ b/smart_fetch/cli_utils.py
@@ -171,19 +171,8 @@ def add_since_filter(
             filters[res_type] = {new_param}
 
     if since_mode == SinceMode.CREATED:
-        # There's no meta.created field, so we do the best we can for each resource.
-        add_filter(resources.ALLERGY_INTOLERANCE, "date")
-        add_filter(resources.CONDITION, "recorded-date")
-        # Skip DEVICE since it has no admin date to search on
-        add_filter(resources.DIAGNOSTIC_REPORT, "issued")
-        add_filter(resources.DOCUMENT_REFERENCE, "date")
-        add_filter(resources.ENCOUNTER, "date")  # clinical date, has no admin date
-        add_filter(resources.IMMUNIZATION, "date")  # clinical date, can't search on `recorded`
-        add_filter(resources.MEDICATION_REQUEST, "authoredon")
-        add_filter(resources.OBSERVATION, "date")  # clinical date, can't search on `issued`
-        # Skip PATIENT since it has no admin date to search on
-        add_filter(resources.PROCEDURE, "date")  # clinical date, has no admin date
-        add_filter(resources.SERVICE_REQUEST, "authored")
+        for res_type, field in resources.CREATED_SEARCH_FIELDS.items():
+            add_filter(res_type, field)
     else:  # UPDATED mode
         for res_type in filters:
             add_filter(res_type, "_lastUpdated")

--- a/smart_fetch/lifecycle.py
+++ b/smart_fetch/lifecycle.py
@@ -169,6 +169,11 @@ class OutputMetadata(Metadata):
         done[tag] = timestamp.isoformat()
         self._write()
 
+    def get_earliest_done_date(self) -> datetime.datetime | None:
+        if done := self._contents.get("done"):
+            return min(datetime.datetime.fromisoformat(time) for time in done.values())
+        return None
+
 
 class ManagedMetadata(Metadata):
     def __init__(self, folder: str):

--- a/smart_fetch/resources.py
+++ b/smart_fetch/resources.py
@@ -37,3 +37,75 @@ SCOPE_TYPES = {
     BINARY,
     MEDICATION,
 }
+
+# These are the fields to search for to ask "when was this record created?"
+# (i.e. the administrative date, not the clinical date for "when did this described event happen?")
+# Would be nice if there were a `meta.created` field.
+# If you update this, update the get_created_date call below too.
+CREATED_SEARCH_FIELDS = {
+    ALLERGY_INTOLERANCE: "date",
+    CONDITION: "recorded-date",
+    # DEVICE has no admin date to search on
+    DIAGNOSTIC_REPORT: "issued",
+    DOCUMENT_REFERENCE: "date",
+    ENCOUNTER: "date",  # clinical date, has no admin date
+    IMMUNIZATION: "date",  # clinical date, can't search on `recorded`
+    MEDICATION_REQUEST: "authoredon",
+    OBSERVATION: "date",  # clinical date, can't search on `issued`
+    # PATIENT has no admin date to search on
+    PROCEDURE: "date",  # clinical date, has no admin date
+    SERVICE_REQUEST: "authored",
+}
+
+
+# Get the FHIR version of the search params above.
+# Even where there is a better field available in FHIR than searching (e.g. "issued" for
+# Observations is available in FHIR, but not when searching), we prefer the searching fields.
+# This is so that we can best match apples to apples.
+# If you update this, update the CREATED_SEARCH_FIELDS dictionary above too.
+def get_created_date(resource: dict) -> str | None:
+    res_type = resource["resourceType"]
+    if res_type not in CREATED_SEARCH_FIELDS:
+        return None
+
+    if res_type == ALLERGY_INTOLERANCE:
+        return resource.get("recordedDate")
+    elif res_type == CONDITION:
+        return resource.get("recordedDate")
+    elif res_type == DIAGNOSTIC_REPORT:
+        return resource.get("issued")
+    elif res_type == DOCUMENT_REFERENCE:
+        return resource.get("date")
+    elif res_type == ENCOUNTER:
+        if parsed := resource.get("period", {}).get("start"):
+            return parsed
+        if parsed := resource.get("period", {}).get("end"):
+            return parsed
+    elif res_type == IMMUNIZATION:
+        return resource.get("occurrenceDateTime")
+    elif res_type == MEDICATION_REQUEST:
+        return resource.get("authoredOn")
+    elif res_type == OBSERVATION:
+        if parsed := resource.get("effectiveDateTime"):
+            return parsed
+        if parsed := resource.get("effectiveInstant"):
+            return parsed
+        if parsed := resource.get("effectivePeriod", {}).get("start"):
+            return parsed
+        if parsed := resource.get("effectivePeriod", {}).get("end"):
+            return parsed
+    elif res_type == PROCEDURE:
+        if parsed := resource.get("performedDateTime"):
+            return parsed
+        if parsed := resource.get("performedPeriod", {}).get("start"):
+            return parsed
+        if parsed := resource.get("performedPeriod", {}).get("end"):
+            return parsed
+    elif res_type == SERVICE_REQUEST:
+        return resource.get("authoredOn")
+
+    return None
+
+
+def get_updated_date(resource: dict) -> str | None:
+    return resource.get("meta", {}).get("lastUpdated")

--- a/smart_fetch/timing.py
+++ b/smart_fetch/timing.py
@@ -3,3 +3,40 @@ import datetime
 
 def now() -> datetime.datetime:
     return datetime.datetime.now(datetime.UTC).astimezone()
+
+
+def parse_datetime(value: str | None) -> datetime.datetime | None:
+    """
+    Convert a FHIR dateTime type to a Python datetime object.
+
+    This is mostly used for comparing dates and timestamps, so sometimes sacrifices a little
+    accuracy to get a useful Python comparison object.
+
+    See https://www.hl7.org/fhir/R4/datatypes.html#dateTime for format details.
+    """
+    if not value:
+        return None
+
+    # datetime.fromisoformat() only handles dates at least to the day level.
+    # But FHIR allows YYYY and YYYY-MM formats too. So we need to manually handle those.
+    # We fill in the missing bits with "01", which is not entirely capturing the intent of the
+    # short format (which covers a range), but to work with a datetime we need a date and it's
+    # safer to go earlier.
+    if len(value) == 4:
+        value += "-01-01"
+    elif len(value) == 7:
+        value += "-01"
+
+    try:
+        parsed = datetime.datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+    # Because we are mostly interested in comparing timestamps, we need all dates to be aware (not
+    # naive) - so set an arbitrary timezone of UTC. Local timezone wouldn't make any more or less
+    # sense because who knows what timezone the EHR is in, but it would make testing more annoying.
+    # So UTC it is.
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.UTC)
+
+    return parsed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -247,3 +247,7 @@ but found:
     @ddt.unpack
     def test_unit_human_file_size(self, size, expected_string):
         self.assertEqual(cli_utils.human_file_size(size), expected_string)
+
+    def test_unit_metadata_no_earliest_done(self):
+        """Confirm we return None if there is no earliest done date"""
+        self.assertIsNone(lifecycle.OutputMetadata(self.folder).get_earliest_done_date())


### PR DESCRIPTION
This branch has 3 commits, two small and one main one.

Small ones:
- when picking a non-default auto value, tell the user: with the default --since-mode=auto and --export-mode=auto, if we detect a server that can't handle the default and fall back to a non-default value, print that to the user.
- print done message at end of command: do a nice little print when a command finishes, so the user knows, if they are watching a log file rather than the console

Main one: use an older transaction time if the server provides stale data

If the server is on a delay and serving data from a month ago, when we record a transaction time from a crawl, we should only go as far as the latest data we saw (vs "now") because when the server refreshes, we don't want to skip the past month of data.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
