### PR TITLE
feat: add new 'single' command to get a single query

### DIFF
--- a/smart_fetch/cli/bulk.py
+++ b/smart_fetch/cli/bulk.py
@@ -59,6 +59,8 @@ async def export_main(args: argparse.Namespace) -> None:
             since_mode=since_mode,
         )
 
+    cli_utils.print_done()
+
 
 async def cancel_bulk(bulk_client: cfs.FhirClient, workdir: str) -> None:
     metadata = lifecycle.OutputMetadata(workdir)

--- a/smart_fetch/cli/crawl.py
+++ b/smart_fetch/cli/crawl.py
@@ -62,3 +62,5 @@ async def crawl_main(args: argparse.Namespace) -> None:
             mrn_file=args.mrn_file,
             mrn_system=args.mrn_system,
         )
+
+    cli_utils.print_done()

--- a/smart_fetch/cli/export.py
+++ b/smart_fetch/cli/export.py
@@ -110,6 +110,8 @@ async def export_main(args: argparse.Namespace) -> None:
                 finish_callback=partial(finish_resource, rest_client, workdir),
             )
 
+    cli_utils.print_done()
+
 
 def calculate_export_mode(export_mode: ExportMode, server_type: cfs.ServerType) -> ExportMode:
     if not export_mode or export_mode == ExportMode.AUTO:

--- a/smart_fetch/cli/hydrate.py
+++ b/smart_fetch/cli/hydrate.py
@@ -61,3 +61,5 @@ async def hydrate_main(args: argparse.Namespace) -> None:
                 await tasks.all_tasks[task_name][2](
                     client, args.folder, source_dir=args.source_dir, mimetypes=args.mimetypes
                 )
+
+    cli_utils.print_done()

--- a/smart_fetch/cli/main.py
+++ b/smart_fetch/cli/main.py
@@ -7,7 +7,7 @@ import sys
 
 import rich.logging
 
-from smart_fetch.cli import bulk, crawl, export, hydrate
+from smart_fetch.cli import bulk, crawl, export, hydrate, single
 
 
 def define_parser() -> argparse.ArgumentParser:
@@ -21,6 +21,7 @@ def define_parser() -> argparse.ArgumentParser:
         subparsers.add_parser("crawl", help="run a crawl (REST alternative to bulk export)")
     )
     hydrate.make_subparser(subparsers.add_parser("hydrate", help="add to already-exported data"))
+    single.make_subparser(subparsers.add_parser("single", help="request a single resource"))
 
     return parser
 
@@ -37,9 +38,6 @@ async def main(argv: list[str]) -> None:
     parser = define_parser()
     args = parser.parse_args(argv)
     await args.func(args)
-
-    rich.get_console().rule()
-    rich.get_console().print("✨ Done ✨")
 
 
 def main_cli():

--- a/smart_fetch/cli/single.py
+++ b/smart_fetch/cli/single.py
@@ -1,0 +1,56 @@
+"""Request a single query"""
+
+import argparse
+import base64
+import sys
+
+import cumulus_fhir_support as cfs
+import rich
+import rich.highlighter
+import rich.progress
+
+from smart_fetch import cli_utils, ndjson, resources
+
+
+def make_subparser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("resource", metavar="ResourceType/ID")
+    cli_utils.add_general(parser)
+    parser.add_argument(
+        "--binary",
+        action="store_true",
+        help="if resource is a Binary object, prints the underlying binary data rather than JSON",
+    )
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="print JSON in compact mode (all on one line)",
+    )
+
+    cli_utils.add_auth(parser)
+    parser.set_defaults(func=single_main)
+
+
+async def single_main(args: argparse.Namespace) -> None:
+    """Exports data from an EHR to a folder."""
+    rest_client, _bulk_client = cli_utils.prepare(args)
+
+    async with rest_client:
+        try:
+            response = await rest_client.request("GET", args.resource)
+        except cfs.NetworkError as exc:
+            sys.exit(str(exc))
+
+        fhir_json = response.json()
+
+        if args.binary and fhir_json.get("resourceType") == resources.BINARY:
+            data = fhir_json.get("data", "")
+            binary = base64.standard_b64decode(data)
+            sys.stdout.buffer.write(binary)
+        elif args.compact:
+            # Use our extremely tight formatting (no spaces at all),
+            # but with rich's nice highlighting
+            compact_str = ndjson.compact_json(fhir_json)
+            compact_str = rich.highlighter.JSONHighlighter()(compact_str)
+            rich.get_console().print(compact_str, soft_wrap=True)
+        else:
+            rich.print_json(data=fhir_json)

--- a/smart_fetch/cli_utils.py
+++ b/smart_fetch/cli_utils.py
@@ -376,3 +376,8 @@ def human_time_offset(seconds: int) -> str:
 
     hours = minutes / 60
     return f"{_pretty_float(hours)}h"
+
+
+def print_done() -> None:
+    rich.get_console().rule()
+    rich.print("✨ Done ✨")

--- a/smart_fetch/ndjson.py
+++ b/smart_fetch/ndjson.py
@@ -42,9 +42,7 @@ class NdjsonWriter:
         # lazily create the file, to avoid 0-line ndjson files
         self._ensure_file()
 
-        # Specify separators for the most compact (no whitespace) representation saves disk space.
-        json.dump(obj, self._file, separators=(",", ":"))
-        self._file.write("\n")
+        self._file.write(compact_json(obj) + "\n")
 
 
 def read_local_line_count(path) -> int:
@@ -63,3 +61,9 @@ def read_local_line_count(path) -> int:
     if buf and buf[-1] != ord("\n"):  # catch a final line without a trailing newline
         count += 1
     return count
+
+
+def compact_json(obj: dict) -> str:
+    """Formats JSON with no whitespace"""
+    # Specify separators for the most compact (no whitespace) representation saves disk space.
+    return json.dumps(obj, separators=(",", ":"))

--- a/tests/test_single.py
+++ b/tests/test_single.py
@@ -1,0 +1,91 @@
+import base64
+
+from tests import utils
+
+
+class SingleTests(utils.TestCase):
+    async def test_basic(self):
+        self.server.get("Patient/alice").respond(
+            200,
+            json={
+                "resourceType": "Patient",
+                "id": "alice",
+            },
+        )
+
+        stdout, stderr = await self.capture_cli("single", "Patient/alice")
+
+        self.assertEqual(
+            stdout,
+            b"""{
+  "resourceType": "Patient",
+  "id": "alice"
+}
+""",
+        )
+        self.assertEqual(stderr, "")
+
+    async def test_internal_newlines(self):
+        self.server.get("Patient/alice").respond(
+            200,
+            json={"resourceType": "Patient", "id": "alice", "text": {"div": "long\ntext\nfield"}},
+        )
+
+        # We should be escaping the newlines in all cases, but we especially want to confirm that
+        # we only emit one line in contact mode.
+        stdout, stderr = await self.capture_cli("single", "Patient/alice", "--compact")
+
+        self.assertEqual(
+            stdout,
+            b"""{"resourceType":"Patient","id":"alice","text":{"div":"long\\ntext\\nfield"}}\n""",
+        )
+        self.assertEqual(stderr, "")
+
+    async def test_compact(self):
+        self.server.get("Patient/alice").respond(
+            200,
+            json={
+                "resourceType": "Patient",
+                "id": "alice",
+            },
+        )
+        stdout, stderr = await self.capture_cli("single", "Patient/alice", "--compact")
+        self.assertEqual(stdout, b'{"resourceType":"Patient","id":"alice"}\n')
+        self.assertEqual(stderr, "")
+
+    async def test_binary(self):
+        # Use non-utf8 to confirm we print without trying to decode to a string
+        invalid_utf8 = b"\xc3\x28"
+        # sanity check that we have a non-utf8-string value
+        with self.assertRaises(UnicodeDecodeError):
+            invalid_utf8.decode("utf8")
+
+        self.server.get("Binary/test").respond(
+            200,
+            json={
+                "resourceType": "Binary",
+                "contentType": "application/custom",
+                "data": base64.standard_b64encode(invalid_utf8).decode("ascii"),
+            },
+        )
+        stdout, stderr = await self.capture_cli("single", "Binary/test", "--binary")
+        self.assertEqual(stdout, invalid_utf8)  # note the (correct) lack of a newline
+        self.assertEqual(stderr, "")
+
+    async def test_binary_no_data(self):
+        """Just confirm we don't blow up, mostly"""
+        self.server.get("Binary/test").respond(
+            200,
+            json={
+                "resourceType": "Binary",
+                "contentType": "application/custom",
+            },
+        )
+        stdout, stderr = await self.capture_cli("single", "Binary/test", "--binary")
+        self.assertEqual(stdout, b"")
+        self.assertEqual(stderr, "")
+
+    async def test_error(self):
+        self.server.get("Patient/alice").respond(400, text="bad request, bruh")
+        with self.assertRaisesRegex(SystemExit, "bad request, bruh"):
+            await self.capture_cli("single", "Patient/alice")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,7 @@
+import contextlib
 import datetime
 import gzip
+import io
 import json
 import os
 import pathlib
@@ -110,6 +112,14 @@ class TestCase(unittest.IsolatedAsyncioTestCase):
         default_args = ["--fhir-url", self.url]
         with self.server:
             await main.main([str(arg) for arg in args] + default_args)
+
+    async def capture_cli(self, *args) -> tuple[bytes, str]:
+        stdout = io.TextIOWrapper(io.BytesIO())
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            with contextlib.redirect_stderr(stderr):
+                await self.cli(*args)
+        return stdout.buffer.getvalue(), stderr.getvalue()
 
     def write_res(self, res_type: str, resources: list[dict], subfolder: str | None = None) -> None:
         if subfolder:


### PR DESCRIPTION
This requests one single resource (Patient/abc) or one single search (Patient?active=true).

Prints JSON with pretty highlighting by default, but can also do a compact (one-line) representation with --compact and can also parse Binary data for you with --binary.

This subcommand is helpful for debugging / doing some QA. It's not meant for any kind of bulk access.


### Checklist
- [ ] Consider if documentation (like in `docs/`) needs to be updated
- [ ] Consider if tests should be added
