### PR TITLE
cli: allow --config before the subcommand

### DIFF
--- a/smart_fetch/cli/main.py
+++ b/smart_fetch/cli/main.py
@@ -7,14 +7,20 @@ import sys
 
 import rich.logging
 
+from smart_fetch import cli_utils
 from smart_fetch.cli import bulk, crawl, export, hydrate, single
 
 
 def define_parser() -> argparse.ArgumentParser:
     """Fills out an argument parser with all the CLI options."""
     parser = argparse.ArgumentParser()
+    cli_utils.add_general(parser, root=True)
 
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(
+        description="if you are unsure which you want, start with the high-level 'export' command",
+        metavar="subcommand",
+        required=True,
+    )
     export.make_subparser(subparsers.add_parser("export", help="run a managed export"))
     bulk.make_subparser(subparsers.add_parser("bulk", help="run a bulk export"))
     crawl.make_subparser(

--- a/smart_fetch/cli_utils.py
+++ b/smart_fetch/cli_utils.py
@@ -258,8 +258,9 @@ def add_auth(parser: argparse.ArgumentParser):
 # GENERAL
 
 
-def add_general(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--config", "-c", metavar="PATH", help="config file")
+def add_general(parser: argparse.ArgumentParser, root: bool = False) -> None:
+    default = None if root else argparse.SUPPRESS
+    parser.add_argument("--config", "-c", metavar="PATH", help="config file", default=default)
 
 
 def load_config(args) -> None:


### PR DESCRIPTION
Fixes: https://github.com/smart-on-fhir/smart-fetch/issues/19


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
