### PR TITLE
feat: use per-resource since values when crawling with --since=auto

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,3 +64,31 @@ A reviewer will be looking for things like:
 
 Once approved, you can merge your PR yourself as long as the other GitHub tests pass.
 Congratulations, and thank you!
+
+## Design Explanations
+
+### Dates
+
+There are two main kinds of dates internally: "since" dates and transaction times.
+These interact a little bit, but are different ideas.
+
+A "since" date is a date given by the user (or calculated for them) that we give to the server,
+and the server only returns resources later than that date.
+
+A transaction time is the time up to which an export is "valid" or "complete".
+This is a concept taken from bulk exports (but we also apply it to crawls).
+The server will return all resources up to that transaction time,
+and should not (but may) include resources after that transaction time.
+
+For bulk exports, the server gives us the transaction time.
+For crawls, we calculate one from the data.
+
+Transaction times are stored in metadata files,
+so that when a future `--since=auto` export happens,
+SMART Fetch can go back and use a previous transaction time as the new "since" date.
+
+Bulk exports use a single date for the entire export.
+But crawls keep track of a unique transaction time per-resource.
+They do this because (a) they can and that gives us more flexibility but also
+(b) if one export is rarely created and the last one was created last month,
+we don't want to end up using that one data as the "since" date for all the other resources.

--- a/smart_fetch/cli_utils.py
+++ b/smart_fetch/cli_utils.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import enum
 import logging
 import sys
@@ -152,7 +153,7 @@ def calculate_since_mode(
 
 def add_since_filter(
     filters: Filters,
-    since: str | None,
+    since: str | dict[str, datetime.datetime | None] | None,
     since_mode: SinceMode,
 ) -> Filters:
     """
@@ -174,7 +175,15 @@ def add_since_filter(
     def add_filter(res_type: str, field: str) -> None:
         if res_type not in filters:
             return
-        new_param = f"{field}=gt{since}"
+
+        if isinstance(since, str):
+            res_since = since
+        elif not since.get(res_type):
+            return
+        else:
+            res_since = since[res_type].isoformat()
+        new_param = f"{field}=gt{res_since}"
+
         if filters[res_type]:
             filters[res_type] = {f"{params}&{new_param}" for params in filters[res_type]}
         else:


### PR DESCRIPTION
This way, we duplicate less data, especially if some resources are rarely updated (before, we'd use the since value of the oldest resource).

Bulk export mode remains the same - no easy way to adjust that. But if you're consistently doing bulk exports, you at least have recent transaction times.

Fixes https://github.com/smart-on-fhir/smart-fetch/issues/24

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
