### PR TITLE
feat(export): notice new and deleted patients

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,5 +90,5 @@ SMART Fetch can go back and use a previous transaction time as the new "since" d
 Bulk exports use a single date for the entire export.
 But crawls keep track of a unique transaction time per-resource.
 They do this because (a) they can and that gives us more flexibility but also
-(b) if one export is rarely created and the last one was created last month,
+(b) if one resource is rarely created and the last one was created last month,
 we don't want to end up using that one data as the "since" date for all the other resources.

--- a/docs/exporting.md
+++ b/docs/exporting.md
@@ -96,6 +96,25 @@ You can pass in `--mrn-system=uri:oid:1.2.3.4`
 and `--mrn-file=mrns.txt` (where that file contains a line of `abc`)
 to have SMART Fetch use a cohort that includes this patient.
 
+### New and Deleted Patients
+
+When crawling, SMART Fetch will notice new and deleted patients, just like a bulk export would.
+
+Meaning, historical resources for new and merged patients may be included in the crawl,
+even outside the `--since` timespan.
+New patients added to the Group or the MRN file will be noticed,
+as well as patient records that absorb another record when two patient records merge.
+In that case, we'll pull the historical resources for the surviving record,
+to make sure we have all the updated resources.
+
+And if a patient is deleted by the EHR (or removed from the Group or MRN file),
+that fact will be recorded in a `deleted/` folder, just like it would be for a bulk export.
+Downstream tooling might use that information.
+
+This all relies on looking back at previous exports in the export folder.
+Noticing new and deleted patients should automatically on the server side for a bulk export,
+but SMART Fetch has to do them manually for a crawl.
+
 ## Resuming
 
 If your bulk export (or crawl) gets interrupted, just run the SMART Fetch command again with the

--- a/smart_fetch/merges.py
+++ b/smart_fetch/merges.py
@@ -1,0 +1,110 @@
+"""Code for dealing with merged and newly-appearing Patient resources."""
+
+import os
+
+import cumulus_fhir_support as cfs
+
+from smart_fetch import filtering, lifecycle, resources
+
+
+def find_new_patients(
+    workdir: str,
+    managed_dir: str | None,
+    filters: filtering.Filters,
+) -> tuple[set[str], set[str]]:
+    """
+    Returns new and deleted patient IDs, in that order.
+
+    This is done by looking back for previous Patient exports and finding whether we have more or
+    less patients this time.
+
+    There are a couple sources of new patients (or at least, patients we want to treat as new,
+    in the sense of getting their historical resources the first time we see them):
+    - Literally just newly appeared patients (user added some to their --mrn-file or the Group got
+      expanded)
+    - Merged patients (patient A got merged into patient B - maybe both are pre-existing patients,
+      but we want to treat patient B as new in the sense that we need to update all their
+      historical data in case old patient A resources got updated to point at B)
+
+    And a couple ways of thinking about deleted patients:
+    - Maybe the patient got dropped from the Group or --mrn-file
+    - Merged patients (patient A got merged into patient B) - which can be a soft delete or a hard
+      delete, depending on how the EHR handles it - we follow their lead and only consider the
+      patient deleted if they aren't in the export anymore.
+
+    This relies on the fact that patients must all be exported every time (i.e. there's no date
+    field for "since" to get just a slice of the patients).
+    """
+    if not managed_dir:
+        return set(), set()
+
+    # Now, we go backward in time to find the latest export for patients (with same filters).
+    # Then compare the two sets of patients.
+    for folder in lifecycle.list_workdirs(managed_dir):
+        folder_path = os.path.join(managed_dir, folder)
+        folder_metadata = lifecycle.OutputMetadata(folder_path)
+        if resources.PATIENT in folder_metadata.get_matching_timestamps(filters):
+            previous_patients = _find_replaced_links(folder_path)
+            break
+    else:
+        # No previous patient export - don't report any new or deleted patients
+        return set(), set()
+
+    current_patients = _find_replaced_links(workdir)
+
+    # Check for the easy-to-detect new and deleted patients
+    new_patients = set(current_patients) - set(previous_patients)
+    deleted_patients = set(previous_patients) - set(current_patients)
+
+    # Also check if we've had any new merges since last export, and mark the replacing patients
+    # as new, so we will update their historical records and get any new resources pointed at them.
+    # TODO: should we worry about "un-merged" patients? Like A and B split up after being merged.
+    for patient, current_replacements in current_patients.items():
+        previous_replacements = previous_patients.get(patient, set())
+        if current_replacements - previous_replacements:
+            new_patients.add(patient)
+
+    return new_patients, deleted_patients
+
+
+def _find_replaced_links(workdir: str) -> dict[str, set[str]]:
+    """
+    Return mapping of replacing ID -> replaced IDs (new -> old).
+    """
+    replaced = {}
+
+    for patient in cfs.read_multiline_json_from_dir(workdir, resources.PATIENT):
+        ids = replaced.setdefault(patient["id"], set())
+        for link in patient.get("link", []):
+            if link.get("type") == "replaces":
+                reference = link.get("other", {}).get("reference", "")
+                if reference.startswith(f"{resources.PATIENT}/"):
+                    ids.add(reference.split("/", 1)[-1])
+
+    return replaced
+
+
+def find_new_patients_for_resource(
+    res_type: str,
+    metadata: lifecycle.OutputMetadata,
+    managed_dir: str | None,
+    filters: filtering.Filters,
+) -> set[str]:
+    # Check if we have new patients in our current export - if so, easy-peasy, we'll use those.
+    if new_patients := metadata.get_new_patients():
+        return new_patients
+
+    if not managed_dir:
+        return set()  # can't search backwards through exports, so we're done here
+
+    # Now, we go backward in time to find the latest metadata that references new patients, since
+    # the last time we exported this resource type. We grab any new patients in any exports along
+    # the way (regardless of the filters used - since we can't really know what the user wants,
+    # but all new patients are interesting to us).
+    for folder in lifecycle.list_workdirs(managed_dir):
+        folder_metadata = lifecycle.OutputMetadata(os.path.join(managed_dir, folder))
+        if res_type in folder_metadata.get_matching_timestamps(filters):
+            break
+        new_patients |= folder_metadata.get_new_patients()
+
+    return new_patients

--- a/smart_fetch/resources.py
+++ b/smart_fetch/resources.py
@@ -52,7 +52,7 @@ CREATED_SEARCH_FIELDS = {
     IMMUNIZATION: "date",  # clinical date, can't search on `recorded`
     MEDICATION_REQUEST: "authoredon",
     OBSERVATION: "date",  # clinical date, can't search on `issued`
-    # PATIENT has no admin date to search on
+    # PATIENT has no admin date to search on (which is sort of good - merges.py relies on it)
     PROCEDURE: "date",  # clinical date, has no admin date
     SERVICE_REQUEST: "authored",
 }

--- a/tests/test_merges.py
+++ b/tests/test_merges.py
@@ -1,0 +1,174 @@
+"""Tests for merged, new, and deleted patients."""
+
+import httpx
+
+from tests import utils
+
+
+class MergeTests(utils.TestCase):
+    @staticmethod
+    def deleted(patient_id: str) -> dict:
+        return {
+            "resourceType": "Bundle",
+            "type": "transaction",
+            "entry": [{"request": {"method": "DELETE", "url": f"Patient/{patient_id}"}}],
+        }
+
+    async def test_patient_changes(self):
+        # Initial export
+        pat1 = {"resourceType": "Patient", "id": "pat1"}
+        self.mock_bulk(output=[pat1], params={"_type": "Patient"})
+        await self.cli("export", self.folder, "--type=Patient")
+
+        # Second export, confirm we note new patients even with bulk exports
+        pat2 = {"resourceType": "Patient", "id": "pat2"}
+        pat3 = {"resourceType": "Patient", "id": "pat3"}
+        self.mock_bulk(
+            output=[pat1, pat2, pat3],
+            params={"_type": "Patient", "_since": "2020-10-10T00:00:00Z"},
+        )
+        await self.cli("export", self.folder, "--type=Patient", "--since=2020-10-10T00:00:00Z")
+        self.assert_folder(
+            {
+                "Patient.001.ndjson.gz": None,
+                "Patient.002.ndjson.gz": None,
+                "Patient.003.ndjson.gz": None,
+                "Patient.004.ndjson.gz": None,
+                "001.2021-09-14": None,
+                "002.2021-09-14": {
+                    ".metadata": {
+                        "done": {"Patient": utils.TRANSACTION_TIME},
+                        "filters": {"Patient": []},
+                        "newPatients": ["pat2", "pat3"],
+                        "since": "2020-10-10T00:00:00Z",
+                        "sinceMode": "updated",
+                        "kind": "output",
+                        "timestamp": utils.FROZEN_TIMESTAMP,
+                        "version": utils.version,
+                    },
+                    "log.ndjson": None,
+                    "Patient.001.ndjson.gz": None,
+                    "Patient.002.ndjson.gz": None,
+                    "Patient.003.ndjson.gz": None,
+                },
+                ".metadata": None,
+            }
+        )
+
+        # Third export, as a crawl, with new, deleted, merged, and pre-existing patients
+        pat2["link"] = [{"type": "replaces", "other": {"reference": "Patient/pat1"}}]
+        pat4 = {"resourceType": "Patient", "id": "pat4"}
+        self.mock_bulk(
+            output=[pat2, pat3, pat4],
+            params={"_type": "Patient", "_since": "2021-10-10T00:00:00Z"},
+        )
+        await self.cli(
+            "export",
+            self.folder,
+            "--type=Patient",
+            "--export-mode=crawl",
+            "--since=2021-10-10T00:00:00Z",
+        )
+        self.assert_folder(
+            {
+                "Patient.001.ndjson.gz": None,
+                "Patient.002.ndjson.gz": None,
+                "Patient.003.ndjson.gz": None,
+                "Patient.004.ndjson.gz": None,
+                "Patient.005.ndjson.gz": None,
+                "Patient.006.ndjson.gz": None,
+                "Patient.007.ndjson.gz": None,
+                "001.2021-09-14": None,
+                "002.2021-09-14": None,
+                "003.2021-09-14": {
+                    ".metadata": {
+                        "done": {"Patient": utils.TRANSACTION_TIME},
+                        "filters": {"Patient": []},
+                        "newPatients": ["pat2", "pat4"],
+                        "since": "2021-10-10T00:00:00Z",
+                        "sinceMode": "updated",
+                        "kind": "output",
+                        "timestamp": utils.FROZEN_TIMESTAMP,
+                        "version": utils.version,
+                    },
+                    "log.ndjson": None,
+                    "Patient.001.ndjson.gz": None,
+                    "Patient.002.ndjson.gz": None,
+                    "Patient.003.ndjson.gz": None,
+                    "deleted": {
+                        "Patient.ndjson.gz": [self.deleted("pat1")],
+                    },
+                },
+                ".metadata": None,
+            }
+        )
+
+    async def test_all_resources_for_new_patients(self):
+        """Confirm we get all resources for any new patients, regardless of --since"""
+        # Initial export
+        pat1 = {"resourceType": "Patient", "id": "pat1"}
+        self.mock_bulk(output=[pat1], params={"_type": "Condition,Patient"})
+        await self.cli("export", self.folder, "--type=Condition,Patient")
+
+        # Second export of just patients, with a new patient
+        pat2 = {"resourceType": "Patient", "id": "pat2"}
+        self.mock_bulk(output=[pat1, pat2], params={"_type": "Patient"})
+        await self.cli("export", self.folder, "--type=Patient")
+
+        # Crawl export of Condition, should pick up all conditions for new patient
+        params = {
+            "Condition": [
+                httpx.QueryParams(patient="pat1", _lastUpdated=f"gt{utils.TRANSACTION_TIME}"),
+                httpx.QueryParams(patient="pat2"),
+            ]
+        }
+        missing = self.set_resource_search_queries(params)
+        await self.cli(
+            "export",
+            self.folder,
+            "--type=Condition",
+            "--export-mode=crawl",
+            f"--since={utils.TRANSACTION_TIME}",
+        )
+        self.assertEqual(missing, [])
+
+        # Another export of Condition, should treat both patients the same now
+        params = {
+            "Condition": [
+                httpx.QueryParams(patient="pat1", _lastUpdated="gt2024-10-17T12:00:00-05:00"),
+                httpx.QueryParams(patient="pat2", _lastUpdated="gt2024-10-17T12:00:00-05:00"),
+            ]
+        }
+        missing = self.set_resource_search_queries(params)
+        await self.cli(
+            "export",
+            self.folder,
+            "--type=Condition",
+            "--export-mode=crawl",
+            "--since=2024-10-17T12:00:00-05:00",
+        )
+        self.assertEqual(missing, [])
+
+        # An export of Condition & Patient, with a new patient.
+        # We should immediately grab all the conditions for new patients.
+        pat3 = {"resourceType": "Patient", "id": "pat3"}
+        self.mock_bulk(
+            output=[pat1, pat2, pat3],
+            params={"_type": "Patient", "_since": "2024-10-18T12:00:00-05:00"},
+        )
+        params = {
+            "Condition": [
+                httpx.QueryParams(patient="pat1", _lastUpdated="gt2024-10-18T12:00:00-05:00"),
+                httpx.QueryParams(patient="pat2", _lastUpdated="gt2024-10-18T12:00:00-05:00"),
+                httpx.QueryParams(patient="pat3"),
+            ]
+        }
+        missing = self.set_resource_search_queries(params)
+        await self.cli(
+            "export",
+            self.folder,
+            "--type=Condition,Patient",
+            "--export-mode=crawl",
+            "--since=2024-10-18T12:00:00-05:00",
+        )
+        self.assertEqual(missing, [])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -72,7 +72,7 @@ class TestCase(unittest.IsolatedAsyncioTestCase):
 
     def set_resource_route(self, callback):
         route = self.server.get(
-            url__regex=rf"{self.url}/(?P<res_type>[^/]+)/(?P<res_id>[^/?]+)[^/\$]*$"
+            url__regex=rf"{self.url}/(?P<res_type>[^/]+)/(?P<res_id>[^$/?]+)[^/\$]*$"
         )
         route.side_effect = callback
 
@@ -105,7 +105,7 @@ class TestCase(unittest.IsolatedAsyncioTestCase):
         return all_params
 
     def set_resource_search_route(self, callback):
-        route = self.server.get(url__regex=rf"{self.url}/(?P<res_type>[^/?]+)[^/\$]*$")
+        route = self.server.get(url__regex=rf"{self.url}/(?P<res_type>[^$/?]+)[^/\$]*$")
         route.side_effect = callback
 
     async def cli(self, *args) -> None:


### PR DESCRIPTION
This commit aims to reproduce some bits of how a bulk export handles _since and bring it to the crawl flow.

- If a patient is deleted, record it in the deleted/ folder, like a bulk export would (this is detected by looking back at previous exports)
- If a patient is new (or is the surviving record of two merged records), we now note the new patients and grab all historical resources for them next time we crawl for a resource.

Some things this doesn't do:
- Handle "unmerged" patients (like they got merged, then unmerged again all while both being present) - don't know how realistic that is
- Mark non-patient resources as deleted (harder to track those, and marking the patient as deleted should make the rest of their resources pointless, in downstream tooling)

Fixes https://github.com/smart-on-fhir/smart-fetch/issues/27

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
