### PR TITLE
crawl: stop using clinical dates as fallbacks for admin dates

### DIFF
--- a/docs/since.md
+++ b/docs/since.md
@@ -34,11 +34,11 @@ But that's OK!
 If you pass in `--since-mode=created`, SMART Fetch will use an alternative "since" check.
 
 Instead of using a "when was this resource last updated" check, it will use a
-"when was this resource created" check.
+"when was this resource created" check, for resources that have a "created" timestamp field.
 
 {: .note }
-Created mode is the default "since" mode for Epic servers,
-because Epic does not support `meta.lastUpdated`.
+Created mode is the default for servers that don't
+declare support for the `_lastUpdated` search field (Epic is a notable example).
 
 ### Limitations
 

--- a/smart_fetch/cli/bulk.py
+++ b/smart_fetch/cli/bulk.py
@@ -46,7 +46,7 @@ async def export_main(args: argparse.Namespace) -> None:
         res_types = cli_utils.limit_to_server_resources(bulk_client, res_types)
         filters = filtering.Filters(
             res_types,
-            server_type=bulk_client.server_type,
+            client=bulk_client,
             type_filters=args.type_filter,
             since=args.since,
             since_mode=args.since_mode,

--- a/smart_fetch/cli/crawl.py
+++ b/smart_fetch/cli/crawl.py
@@ -43,7 +43,7 @@ async def crawl_main(args: argparse.Namespace) -> None:
         res_types = cli_utils.limit_to_server_resources(rest_client, res_types)
         filters = filtering.Filters(
             res_types,
-            server_type=rest_client.server_type,
+            client=rest_client,
             type_filters=args.type_filter,
             since=args.since,
             since_mode=args.since_mode,

--- a/smart_fetch/cli/export.py
+++ b/smart_fetch/cli/export.py
@@ -71,7 +71,7 @@ async def export_main(args: argparse.Namespace) -> None:
         source_dir = args.folder
         filters = filtering.Filters(
             res_types,
-            server_type=client.server_type,
+            client=client,
             type_filters=args.type_filter,
             since=args.since,
             since_mode=args.since_mode,

--- a/smart_fetch/crawl_utils.py
+++ b/smart_fetch/crawl_utils.py
@@ -227,7 +227,7 @@ async def finish_wrapper(
             rich.print(f"Count of new patients: {len(new):,}.")
         if deleted:
             _save_deleted_patients(workdir, deleted)
-            rich.print(f"Count of deleted patients: {len(deleted):,}")
+            rich.print(f"Count of deleted patients: {len(deleted):,}.")
 
     # If `timestamp` (which is when we started crawling) is earlier than our latest found date,
     # use it as our transaction time instead (this way we ensure we don't miss any resources that
@@ -328,6 +328,8 @@ def update_transaction_time(
     transaction_times: dict[str, datetime.datetime], res_type: str, val: str | None
 ) -> None:
     if parsed := timing.parse_datetime(val):
+        if parsed > datetime.datetime.now(datetime.UTC):
+            return  # exclude mistaken / typo dates that are in the future
         if res_type not in transaction_times or transaction_times[res_type] < parsed:
             transaction_times[res_type] = parsed
 

--- a/smart_fetch/resources.py
+++ b/smart_fetch/resources.py
@@ -41,6 +41,17 @@ SCOPE_TYPES = {
 # These are the fields to search for to ask "when was this record created?"
 # (i.e. the administrative date, not the clinical date for "when did this described event happen?")
 # Would be nice if there were a `meta.created` field.
+#
+# Some fields do have clinical dates that we could try to use as a fallback proxy,
+# when the resource doesn't let you search on an administrative date, but... in practice that's
+# no good. Take Immunization.occurrenceDateTime (searched with date=). Sometimes older vaccinations
+# get imported into an EHR from external sources. You'd miss those with date=. Or sometimes it
+# can take a day or two for even your own institutional data to be reflected in the system. So
+# we might miss some events near our search date.
+#
+# Thankfully, the resources that tend to have no admin date also tend to be somewhat small.
+# So we'll just get them all each time, without using a search field.
+#
 # If you update this, update the get_created_date call below too.
 CREATED_SEARCH_FIELDS = {
     ALLERGY_INTOLERANCE: "date",
@@ -48,25 +59,20 @@ CREATED_SEARCH_FIELDS = {
     # DEVICE has no admin date to search on
     DIAGNOSTIC_REPORT: "issued",
     DOCUMENT_REFERENCE: "date",
-    ENCOUNTER: "date",  # clinical date, has no admin date
-    IMMUNIZATION: "date",  # clinical date, can't search on `recorded`
+    # ENCOUNTER: has no admin date to search on (but does have clinical date of "date")
+    # IMMUNIZATION has `recorded` but you can't search it (but does have clinical date of "date")
     MEDICATION_REQUEST: "authoredon",
-    OBSERVATION: "date",  # clinical date, can't search on `issued`
+    OBSERVATION: "issued",  # not searchable per spec, but some servers allow it (notably, Epic)
     # PATIENT has no admin date to search on (which is sort of good - merges.py relies on it)
-    PROCEDURE: "date",  # clinical date, has no admin date
+    # PROCEDURE: has no admin date to search on (but does have clinical date of "date")
     SERVICE_REQUEST: "authored",
 }
 
 
 # Get the FHIR version of the search params above.
-# Even where there is a better field available in FHIR than searching (e.g. "issued" for
-# Observations is available in FHIR, but not when searching), we prefer the searching fields.
-# This is so that we can best match apples to apples.
 # If you update this, update the CREATED_SEARCH_FIELDS dictionary above too.
 def get_created_date(resource: dict) -> str | None:
     res_type = resource["resourceType"]
-    if res_type not in CREATED_SEARCH_FIELDS:
-        return None
 
     if res_type == ALLERGY_INTOLERANCE:
         return resource.get("recordedDate")
@@ -76,31 +82,12 @@ def get_created_date(resource: dict) -> str | None:
         return resource.get("issued")
     elif res_type == DOCUMENT_REFERENCE:
         return resource.get("date")
-    elif res_type == ENCOUNTER:
-        if parsed := resource.get("period", {}).get("start"):
-            return parsed
-        if parsed := resource.get("period", {}).get("end"):
-            return parsed
     elif res_type == IMMUNIZATION:
-        return resource.get("occurrenceDateTime")
+        return resource.get("recorded")  # not searchable yet, but grab it for the future
     elif res_type == MEDICATION_REQUEST:
         return resource.get("authoredOn")
     elif res_type == OBSERVATION:
-        if parsed := resource.get("effectiveDateTime"):
-            return parsed
-        if parsed := resource.get("effectiveInstant"):
-            return parsed
-        if parsed := resource.get("effectivePeriod", {}).get("start"):
-            return parsed
-        if parsed := resource.get("effectivePeriod", {}).get("end"):
-            return parsed
-    elif res_type == PROCEDURE:
-        if parsed := resource.get("performedDateTime"):
-            return parsed
-        if parsed := resource.get("performedPeriod", {}).get("start"):
-            return parsed
-        if parsed := resource.get("performedPeriod", {}).get("end"):
-            return parsed
+        return resource.get("issued")
     elif res_type == SERVICE_REQUEST:
         return resource.get("authoredOn")
 

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -194,12 +194,9 @@ class BulkTests(utils.TestCase):
             f"{resources.CONDITION}?recorded-date=gt2022-01-05",
             f"{resources.DIAGNOSTIC_REPORT}?issued=gt2022-01-05",
             f"{resources.DOCUMENT_REFERENCE}?date=gt2022-01-05",
-            f"{resources.ENCOUNTER}?date=gt2022-01-05",
-            f"{resources.IMMUNIZATION}?date=gt2022-01-05",
             f"{resources.MEDICATION_REQUEST}?authoredon=gt2022-01-05",
             f"{resources.OBSERVATION}?category=social-history,vital-signs,imaging,laboratory,"
-            f"survey,exam,procedure,therapy,activity&date=gt2022-01-05",
-            f"{resources.PROCEDURE}?date=gt2022-01-05",
+            f"survey,exam,procedure,therapy,activity&issued=gt2022-01-05",
             f"{resources.SERVICE_REQUEST}?authored=gt2022-01-05",
         ]
         type_filter = ",".join(f.replace(",", "%2C") for f in filters)


### PR DESCRIPTION
When using --since-mode=created, we had been using clinical dates for resources that didn't have admin dates.

But in practice, that seems fraught. Mostly because slightly-backdated resources might be missed around the cutoff date.

Since the affected resources are not huge by volume usually, we'll just grab all of them each time (like we do for Device and Patient already).

Also, this commit will ignore any potential transaction time dates that are in the future, when examining the data (these are likely mistakes) - but I saw this happen in real data.

And also also, this commit uses `Observation.issued` instead of `Observation.date` as the created search field - it's the admin date, which isn't normally searchable, but Epic does support it. So we now look at the server and see which fields it supports before using any of them.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
