### PR TITLE
When doing a full export, record deleted resources

### DIFF
--- a/smart_fetch/filtering.py
+++ b/smart_fetch/filtering.py
@@ -77,6 +77,20 @@ class Filters:
     def resources(self) -> set[str]:
         return set(self._filters)
 
+    def since_resources(self) -> set[str]:
+        """Returns all resources that will have a "since" filter applied to them"""
+        if not self.since:
+            return set()
+
+        if self.since_mode == SinceMode.CREATED:
+            return {
+                res_type
+                for res_type, field in resources.CREATED_SEARCH_FIELDS.items()
+                if self._is_search_field_supported(res_type, field)
+            }
+
+        return self.resources()
+
     def params(self, *, with_since: bool = True, bulk: bool = False) -> TypeFilters:
         """
         Returns search / _typeFilter parameters for this set of filters.
@@ -169,6 +183,9 @@ class Filters:
         return since_mode
 
     def _is_search_field_supported(self, res_type: str, field: str) -> bool:
+        if not self._client:
+            return False
+
         for rest in self._client.capabilities.get("rest", []):
             if rest.get("mode") == "server":
                 break

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -174,7 +174,6 @@ class BulkTests(utils.TestCase):
                     "done": {resources.PATIENT: utils.TRANSACTION_TIME},
                     "filters": {resources.PATIENT: []},
                     "since": None,
-                    "sinceMode": None,
                 },
             }
         )
@@ -251,6 +250,15 @@ class BulkTests(utils.TestCase):
                     "kind": "output",
                     "since": "2022-01-05",
                     "sinceMode": "created",
+                    "sinceResources": [
+                        "AllergyIntolerance",
+                        "Condition",
+                        "DiagnosticReport",
+                        "DocumentReference",
+                        "MedicationRequest",
+                        "Observation",
+                        "ServiceRequest",
+                    ],
                     "timestamp": utils.FROZEN_TIMESTAMP,
                     "version": utils.version,
                 },
@@ -450,7 +458,6 @@ class BulkTests(utils.TestCase):
                     "version": utils.version,
                     "filters": {resources.DEVICE: []},
                     "since": None,
-                    "sinceMode": None,
                 },
                 "log.ndjson": None,
             }

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -51,7 +51,6 @@ class CrawlTests(utils.TestCase):
                     "done": {resources.DEVICE: utils.FROZEN_TIMESTAMP},
                     "filters": {resources.DEVICE: []},
                     "since": None,
-                    "sinceMode": None,
                 },
                 "log.ndjson": [
                     {
@@ -286,7 +285,6 @@ class CrawlTests(utils.TestCase):
                     "filters": {resources.OBSERVATION: expected_filter_metadata},
                     "kind": "output",
                     "since": None,
-                    "sinceMode": None,
                     "timestamp": utils.FROZEN_TIMESTAMP,
                     "version": utils.version,
                 },
@@ -433,6 +431,7 @@ class CrawlTests(utils.TestCase):
                     },
                     "since": "2022-01-05",
                     "sinceMode": "updated",
+                    "sinceResources": ["Encounter", "Immunization"],
                 },
                 f"{resources.PATIENT}.ndjson.gz": None,
                 "log.ndjson": None,
@@ -694,7 +693,6 @@ class CrawlTests(utils.TestCase):
                         resources.SERVICE_REQUEST: [],
                     },
                     "since": None,
-                    "sinceMode": None,
                 },
                 f"{resources.ALLERGY_INTOLERANCE}.ndjson.gz": None,
                 f"{resources.CONDITION}.ndjson.gz": None,


### PR DESCRIPTION
This commit does three interrelated things:

1. Adds a new metadata field "sinceResources" which notes the resources that were subject to a --since parameter (i.e. not fully exported). This is useful because whether a resource is since-ified is subject to the whims of the server and updates in smart-fetch - i.e. it can change on us. So to be sure what smart-fetch did last time, we now record the list.

2. No longer allow resuming too-old exports (i.e. exports past the most recent export). That is, if you start export A, abandon it, then start export B, AND THEN start another export that looks like A, smart-fetch will now make a new export folder rather than resuming the original A export. This is to guarantee that export folders are in time-order. Which helps if we want to iterate back through them, examining what they did.

3. Which we do! When a new full export happens in either bulk or crawl mode, we now look back through previous exports and see if any resources were deleted from the last full export (and its incremental updates along the way).


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
