### PR TITLE
Add EpisodeOfCare as a toplevel patient resource and a hydration task

### DIFF
--- a/docs/since.md
+++ b/docs/since.md
@@ -68,7 +68,9 @@ But it's something to be aware of.
 Resource types affected by this:
 - Device
 - Encounter
+- EpisodeOfCare
 - Immunization
+- MedicationDispense
 - Patient
 - Procedure
 

--- a/smart_fetch/bulk_utils.py
+++ b/smart_fetch/bulk_utils.py
@@ -517,7 +517,10 @@ class BulkExporter:
             return True
         except cfs.RequestError as err:
             # Don't bail on ETL as a whole, this isn't a show stopper error.
-            logging.warning(f"Failed to clean up export job on the server side: {err}")
+            # Also, totally ignore it if it's a 404 (which some servers like HAPI give back because
+            # they auto-delete the job for you)
+            if not isinstance(err, cfs.NetworkError) or err.response.status_code != 404:
+                logging.warning(f"Failed to clean up export job on the server side: {err}")
             return False
 
     async def _request_with_delay_status(self, *args, **kwargs) -> httpx.Response:

--- a/smart_fetch/cli/export.py
+++ b/smart_fetch/cli/export.py
@@ -5,7 +5,6 @@ import datetime
 import enum
 import os
 import sys
-from functools import partial
 
 import cumulus_fhir_support as cfs
 import rich
@@ -112,16 +111,6 @@ async def export_main(args: argparse.Namespace) -> None:
                 managed_dir=source_dir,
                 compress=args.compress,
             )
-            await finish_resource(
-                rest_client,
-                workdir,
-                source_dir,
-                filters,
-                filters.resources(),
-                open_client=True,
-                hydration_tasks=hydration_tasks,
-                compress=args.compress,
-            )
         else:
             await crawl_utils.perform_crawl(
                 fhir_url=args.fhir_url,
@@ -137,16 +126,16 @@ async def export_main(args: argparse.Namespace) -> None:
                 id_list=args.id_list,
                 id_system=args.id_system,
                 compress=args.compress,
-                finish_callback=partial(
-                    finish_resource,
-                    rest_client,
-                    workdir,
-                    source_dir,
-                    filters,
-                    hydration_tasks=hydration_tasks,
-                    compress=args.compress,
-                ),
             )
+
+    await finish_resources(
+        rest_client,
+        workdir,
+        source_dir,
+        filters,
+        hydration_tasks=hydration_tasks,
+        compress=args.compress,
+    )
 
     lifecycle.OutputMetadata(workdir).mark_complete()
     cli_utils.print_done()
@@ -240,33 +229,24 @@ def find_workdir(
     return folder
 
 
-async def finish_resource(
+async def finish_resources(
     client: cfs.FhirClient,
     workdir: str,
     managed_dir: str,
     filters: filtering.Filters,
-    res_types: str | set[str],
     *,
-    open_client: bool = False,
     hydration_tasks: list[type[hydrate_utils.Task]],
-    compress: bool = False,
+    compress: bool,
 ):
-    if isinstance(res_types, str):
-        res_types = {res_types}
-
-    run_tasks = run_hydration_tasks(client, workdir, res_types, hydration_tasks, compress=compress)
-    if open_client:
-        async with client:
-            await run_tasks
-    else:
-        await run_tasks
+    async with client:
+        await run_hydration_tasks(
+            client, workdir, filters.resources(), hydration_tasks, compress=compress
+        )
 
     # Check for deleted resources if we are doing a full update (non-incremental / non-since).
     # (Regardless of bulk or crawl mode, even when we're in bulk which gives us deleted info for
     # since runs, because we still want the deleted info from the last full export.)
-    # Always re-run this, because hydration tasks always re-run, and they could have pulled
-    # something new.
-    for res_type in res_types:
+    for res_type in filters.resources():
         if res_type not in filters.since_resources():
             merges.note_deleted_resource(res_type, workdir, managed_dir, filters, compress=compress)
 

--- a/smart_fetch/crawl_utils.py
+++ b/smart_fetch/crawl_utils.py
@@ -54,7 +54,6 @@ async def perform_crawl(
     id_file: str | None,
     id_list: str | None,
     id_system: str | None,
-    finish_callback: Callable[[str], Awaitable[None]] | None = None,
     managed_dir: str | None = None,
     compress: bool = False,
 ) -> None:
@@ -94,7 +93,6 @@ async def perform_crawl(
     processor_finish = partial(
         finish_wrapper,
         metadata,
-        finish_callback,
         transaction_times,
         workdir,
         managed_dir,
@@ -120,8 +118,6 @@ async def perform_crawl(
     if resources.PATIENT in filter_params:
         if metadata.is_done(resources.PATIENT):
             rich.print(f"Skipping {resources.PATIENT}, already done.")
-            if finish_callback:
-                await finish_callback(resources.PATIENT)
         else:
             download_patients = True
         del filter_params[resources.PATIENT]
@@ -164,8 +160,19 @@ async def perform_crawl(
     for res_type in filter_params:
         if metadata.is_done(res_type):
             rich.print(f"Skipping {res_type}, already done.")
-            if finish_callback:
-                await finish_callback(res_type)
+            continue
+
+        if res_type == resources.EPISODE_OF_CARE and rest_client.server_type == cfs.ServerType.EPIC:
+            # Epic requires both a patient= and a type= argument, and you can't get clever with the
+            # type arg to be like "type:not=nothing", it has to a specific system AND code.
+            # So until they change that, we will skip crawling EpisodeOfCare just so the user
+            # doesn't end up with a huge amount of error messages from Epic. Hydration will pick
+            # them up instead.
+            rich.print(
+                f"Skipping {res_type}, Epic does not support searching without a type, "
+                "so they will have to be hydrated instead."
+            )
+            metadata.mark_done(res_type, timing.now())
             continue
 
         processor.add_source(
@@ -255,7 +262,6 @@ async def gather_patients(
 
 async def finish_wrapper(
     metadata: lifecycle.OutputMetadata,
-    custom_finish: Callable[[str], Awaitable[None]] | None,
     transaction_times: dict[str, datetime.datetime],
     workdir: str,
     managed_dir: str,
@@ -283,8 +289,6 @@ async def finish_wrapper(
         transaction_times[res_type] = timestamp
 
     metadata.mark_done(res_type, transaction_times[res_type])
-    if custom_finish:
-        await custom_finish(res_type)
 
 
 async def resource_urls_with_new_patients(

--- a/smart_fetch/resources.py
+++ b/smart_fetch/resources.py
@@ -6,6 +6,7 @@ DEVICE = "Device"
 DIAGNOSTIC_REPORT = "DiagnosticReport"
 DOCUMENT_REFERENCE = "DocumentReference"
 ENCOUNTER = "Encounter"
+EPISODE_OF_CARE = "EpisodeOfCare"
 IMMUNIZATION = "Immunization"
 LOCATION = "Location"
 MEDICATION = "Medication"
@@ -21,7 +22,8 @@ PROCEDURE = "Procedure"
 SERVICE_REQUEST = "ServiceRequest"
 
 # All resources that are linked to patients, in the order we usually like to process them.
-# Patient first, Encounter, then the rest.
+# Patient first, Encounter, then the rest. (Encounters so early is due to a Cumulus quirk,
+# where it likes to have Encounters exported before/at-same-time as other patient resources.)
 PATIENT_TYPES = [
     PATIENT,
     ENCOUNTER,
@@ -30,6 +32,7 @@ PATIENT_TYPES = [
     DEVICE,
     DIAGNOSTIC_REPORT,
     DOCUMENT_REFERENCE,
+    EPISODE_OF_CARE,
     IMMUNIZATION,
     MEDICATION_DISPENSE,
     MEDICATION_REQUEST,
@@ -70,6 +73,7 @@ CREATED_SEARCH_FIELDS = {
     DIAGNOSTIC_REPORT: "issued",
     DOCUMENT_REFERENCE: "date",
     # ENCOUNTER: has no admin date to search on (but does have clinical date of "date")
+    # EPISODE_OF_CARE has no admin date (but does have clinical date of "period")
     # IMMUNIZATION has `recorded` but you can't search it (but does have clinical date of "date")
     # MEDICATION_DISPENSE has no admin date to search on (but does have two clinical dates)
     MEDICATION_REQUEST: "authoredon",

--- a/smart_fetch/tasks/__init__.py
+++ b/smart_fetch/tasks/__init__.py
@@ -1,3 +1,4 @@
+from .epofcare import EPISODE_OF_CARE_TASKS
 from .inline import INLINE_TASKS
 from .loc import LOCATION_TASKS
 from .meds import MEDICATION_TASKS
@@ -6,6 +7,7 @@ from .org import ORGANIZATION_TASKS
 from .pract import PRACTITIONER_TASKS
 
 all_tasks = {
+    "episodeofcare": EPISODE_OF_CARE_TASKS,
     "inline": INLINE_TASKS,
     "medication": MEDICATION_TASKS,
     "observation": OBSERVATION_TASKS,

--- a/smart_fetch/tasks/epofcare.py
+++ b/smart_fetch/tasks/epofcare.py
@@ -1,0 +1,34 @@
+"""
+Hydration tasks for EpisodeOfCare.
+
+EpisodeOfCare is a patient-linked resource, so we shouldn't normally need this hydration task.
+But because Epic doesn't really let you crawl EpisodeOfCare (it needs a specific type= argument),
+we need to hydrate at least in the Epic case. And since we have the task, we might as well hydrate
+in all cases in case an EHR hides some on us.
+"""
+
+from smart_fetch import hydrate_utils, resources
+
+
+class DocRefEpOfCareTask(hydrate_utils.ReferenceDownloadTask):
+    NAME = "docref-epofcare"
+    INPUT_RES_TYPE = resources.DOCUMENT_REFERENCE
+    OUTPUT_RES_TYPE = resources.EPISODE_OF_CARE
+    REFS = ("context.encounter*",)
+
+
+class EncEpOfCareTask(hydrate_utils.ReferenceDownloadTask):
+    NAME = "enc-epofcare"
+    INPUT_RES_TYPE = resources.ENCOUNTER
+    OUTPUT_RES_TYPE = resources.EPISODE_OF_CARE
+    REFS = ("episodeOfCare*",)
+
+
+class MedDispEpOfCareTask(hydrate_utils.ReferenceDownloadTask):
+    NAME = "meddisp-epofcare"
+    INPUT_RES_TYPE = resources.MEDICATION_DISPENSE
+    OUTPUT_RES_TYPE = resources.EPISODE_OF_CARE
+    REFS = ("context",)
+
+
+EPISODE_OF_CARE_TASKS = [DocRefEpOfCareTask, EncEpOfCareTask, MedDispEpOfCareTask]

--- a/smart_fetch/tasks/org.py
+++ b/smart_fetch/tasks/org.py
@@ -29,6 +29,13 @@ class EncOrgTask(hydrate_utils.ReferenceDownloadTask):
     REFS = ("hospitalization.origin", "hospitalization.destination", "serviceProvider")
 
 
+class EpOfCareOrgTask(hydrate_utils.ReferenceDownloadTask):
+    NAME = "epofcare-org"
+    INPUT_RES_TYPE = resources.EPISODE_OF_CARE
+    OUTPUT_RES_TYPE = resources.ORGANIZATION
+    REFS = ("managingOrganization",)
+
+
 class ImmOrgTask(hydrate_utils.ReferenceDownloadTask):
     NAME = "imm-org"
     INPUT_RES_TYPE = resources.IMMUNIZATION
@@ -111,6 +118,7 @@ ORGANIZATION_TASKS = [
     DxReportOrgTask,
     DocOrgTask,
     EncOrgTask,
+    EpOfCareOrgTask,
     ImmOrgTask,
     LocOrgTask,
     MedDispOrgTask,

--- a/smart_fetch/tasks/pract.py
+++ b/smart_fetch/tasks/pract.py
@@ -63,6 +63,18 @@ class EncPractitionerRoleTask(EncPractitionerTask):
     OUTPUT_RES_TYPE = resources.PRACTITIONER_ROLE
 
 
+class EpOfCarePractitionerTask(hydrate_utils.ReferenceDownloadTask):
+    NAME = "epofcare-pract"
+    INPUT_RES_TYPE = resources.EPISODE_OF_CARE
+    OUTPUT_RES_TYPE = resources.PRACTITIONER
+    REFS = ("careManager",)
+
+
+class EpOfCarePractitionerRoleTask(EpOfCarePractitionerTask):
+    NAME = "epofcare-practrole"
+    OUTPUT_RES_TYPE = resources.PRACTITIONER_ROLE
+
+
 class ImmPractitionerTask(hydrate_utils.ReferenceDownloadTask):
     NAME = "imm-pract"
     INPUT_RES_TYPE = resources.IMMUNIZATION
@@ -232,6 +244,8 @@ PRACTITIONER_TASKS = [
     DocPractitionerRoleTask,
     EncPractitionerTask,
     EncPractitionerRoleTask,
+    EpOfCarePractitionerTask,
+    EpOfCarePractitionerRoleTask,
     ImmPractitionerTask,
     ImmPractitionerRoleTask,
     MedDispPractitionerTask,

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -225,6 +225,7 @@ class BulkTests(utils.TestCase):
                         "DiagnosticReport": utils.TRANSACTION_TIME,
                         "DocumentReference": utils.TRANSACTION_TIME,
                         "Encounter": utils.TRANSACTION_TIME,
+                        "EpisodeOfCare": utils.TRANSACTION_TIME,
                         "Immunization": utils.TRANSACTION_TIME,
                         "MedicationDispense": utils.TRANSACTION_TIME,
                         "MedicationRequest": utils.TRANSACTION_TIME,
@@ -240,6 +241,7 @@ class BulkTests(utils.TestCase):
                         "DiagnosticReport": [],
                         "DocumentReference": [],
                         "Encounter": [],
+                        "EpisodeOfCare": [],
                         "Immunization": [],
                         "MedicationDispense": [],
                         "MedicationRequest": [],
@@ -399,7 +401,7 @@ class BulkTests(utils.TestCase):
             await self.cli("bulk", self.folder, "--group=group1")
 
     async def test_delete_error_is_ignored(self):
-        self.mock_bulk("group1", delete_response=httpx.Response(404))
+        self.mock_bulk("group1", delete_response=httpx.Response(400))
         # No fatal error
         await self.cli("bulk", self.folder, "--group=group1")
 

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -487,6 +487,7 @@ class CrawlTests(utils.TestCase):
             resources.DIAGNOSTIC_REPORT: [httpx.QueryParams(patient="pat1", issued="gt2022-01-05")],
             resources.DOCUMENT_REFERENCE: [httpx.QueryParams(patient="pat1", date="gt2022-01-05")],
             resources.ENCOUNTER: [httpx.QueryParams(patient="pat1")],  # no extra param
+            resources.EPISODE_OF_CARE: [httpx.QueryParams(patient="pat1")],  # no extra param
             resources.IMMUNIZATION: [httpx.QueryParams(patient="pat1")],  # no extra param
             resources.MEDICATION_DISPENSE: [httpx.QueryParams(patient="pat1")],  # no extra param
             resources.MEDICATION_REQUEST: [
@@ -640,6 +641,11 @@ class CrawlTests(utils.TestCase):
                     {"resourceType": resources.ENCOUNTER, "id": "1"}
                 ]
             },
+            resources.EPISODE_OF_CARE: {
+                httpx.QueryParams(patient="pat1"): [
+                    {"resourceType": resources.EPISODE_OF_CARE, "id": "1"}
+                ]
+            },
             resources.IMMUNIZATION: {
                 httpx.QueryParams(patient="pat1"): [
                     {"resourceType": resources.IMMUNIZATION, "id": "1", "recorded": "2003"}
@@ -713,11 +719,12 @@ class CrawlTests(utils.TestCase):
                         resources.DIAGNOSTIC_REPORT: "2001-01-01T00:00:00+14:00",
                         resources.DOCUMENT_REFERENCE: "2002-01-01T00:00:00+14:00",
                         resources.ENCOUNTER: frozen_plus(0),
+                        resources.EPISODE_OF_CARE: frozen_plus(6),
                         resources.IMMUNIZATION: "2003-01-01T00:00:00+14:00",
-                        resources.MEDICATION_DISPENSE: frozen_plus(7),
+                        resources.MEDICATION_DISPENSE: frozen_plus(8),
                         resources.MEDICATION_REQUEST: "2004-01-01T00:00:00+14:00",
                         resources.OBSERVATION: "2005-01-01T00:00:00+14:00",
-                        resources.PROCEDURE: frozen_plus(10),
+                        resources.PROCEDURE: frozen_plus(11),
                         resources.SERVICE_REQUEST: "2012-01-01T00:00:00+14:00",
                     },
                     "filters": {
@@ -727,6 +734,7 @@ class CrawlTests(utils.TestCase):
                         resources.DIAGNOSTIC_REPORT: [],
                         resources.DOCUMENT_REFERENCE: [],
                         resources.ENCOUNTER: [],
+                        resources.EPISODE_OF_CARE: [],
                         resources.IMMUNIZATION: [],
                         resources.MEDICATION_DISPENSE: [],
                         resources.MEDICATION_REQUEST: [],
@@ -742,6 +750,7 @@ class CrawlTests(utils.TestCase):
                 f"{resources.DIAGNOSTIC_REPORT}.ndjson.gz": None,
                 f"{resources.DOCUMENT_REFERENCE}.ndjson.gz": None,
                 f"{resources.ENCOUNTER}.ndjson.gz": None,
+                f"{resources.EPISODE_OF_CARE}.ndjson.gz": None,
                 f"{resources.IMMUNIZATION}.ndjson.gz": None,
                 f"{resources.MEDICATION_DISPENSE}.ndjson.gz": None,
                 f"{resources.MEDICATION_REQUEST}.ndjson.gz": None,

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -490,11 +490,9 @@ class ExportTests(utils.TestCase):
         if export_mode == "crawl":
             suffix = "ndjson.gz"
             res_time = utils.FROZEN_TIMESTAMP
-            extra_files = {"Patient.001.ndjson.gz": "001.2021-09-14/Patient.001.ndjson.gz"}
         else:
             suffix = "001.ndjson.gz"
             res_time = utils.TRANSACTION_TIME
-            extra_files = {}
 
         # First interrupted run
         with self.assertRaises(RuntimeError):
@@ -525,7 +523,6 @@ class ExportTests(utils.TestCase):
                     f"{resources.DOCUMENT_REFERENCE}.{suffix}": [doc1],
                 },
                 ".metadata": None,
-                **extra_files,
             }
         )
 
@@ -1022,5 +1019,82 @@ class ExportTests(utils.TestCase):
                     "Patient.001.ndjson": [pat1],
                 },
                 ".metadata": None,
+            }
+        )
+
+    async def test_skip_epofcare_with_epic(self):
+        self.server.get("metadata").respond(
+            200, json=self.metadata | {"software": {"name": "Epic"}}
+        )
+
+        pat1 = {"resourceType": resources.PATIENT, "id": "pat1"}
+        self.mock_bulk(output=[pat1])
+
+        await self.cli("export", self.folder, "--type=EpisodeOfCare,Patient")
+
+        self.assert_folder(
+            {
+                ".metadata": None,
+                "Patient.001.ndjson.gz": None,
+                "001.2021-09-14": {
+                    # Check metadata to confirm the EpOfCare timestamp is now()
+                    ".metadata": {
+                        "complete": True,
+                        "done": {
+                            "EpisodeOfCare": utils.FROZEN_TIMESTAMP,
+                            "Patient": utils.TRANSACTION_TIME,
+                        },
+                        "filters": {"EpisodeOfCare": [], "Patient": []},
+                        "kind": "output",
+                        "since": None,
+                        "timestamp": utils.FROZEN_TIMESTAMP,
+                        "version": utils.version,
+                    },
+                    "log.ndjson": None,
+                    "Patient.001.ndjson.gz": None,
+                },
+            }
+        )
+
+    async def test_epofcare_exported_and_hydrated(self):
+        """Confirm we don't duplicate EpOfCare results"""
+        self.mock_bulk(
+            output=[
+                {
+                    "resourceType": "Encounter",
+                    "id": "enc1",
+                    "episodeOfCare": [
+                        {"reference": "EpisodeOfCare/referenced"},
+                        {"reference": "EpisodeOfCare/searched"},
+                    ],
+                },
+                {"resourceType": "EpisodeOfCare", "id": "searched"},
+                {"resourceType": "Patient", "id": "pat1"},
+            ]
+        )
+
+        self.set_basic_resource_route()
+
+        await self.cli("export", self.folder, "--type=Encounter,EpisodeOfCare,Patient")
+
+        self.assert_folder(
+            {
+                ".metadata": None,
+                "Encounter.001.ndjson.gz": None,
+                "EpisodeOfCare.001.ndjson.gz": None,
+                "EpisodeOfCare.002.ndjson.gz": None,
+                "Patient.001.ndjson.gz": None,
+                "001.2021-09-14": {
+                    ".metadata": None,
+                    "log.ndjson": None,
+                    "Encounter.001.ndjson.gz": None,
+                    "EpisodeOfCare.001.ndjson.gz": [
+                        {"resourceType": "EpisodeOfCare", "id": "searched"},
+                    ],
+                    "EpisodeOfCare.referenced.ndjson.gz": [
+                        {"resourceType": "EpisodeOfCare", "id": "referenced"},
+                    ],
+                    "Patient.001.ndjson.gz": None,
+                },
             }
         )

--- a/tests/test_hydrate_epofcare.py
+++ b/tests/test_hydrate_epofcare.py
@@ -1,0 +1,27 @@
+from tests import utils
+
+
+class HydrateEpOfCareTests(utils.TestCase):
+    async def test_basic(self):
+        """Simple EpisodeOfCare hydration from scratch"""
+        self.write_res(
+            "DocumentReference",
+            [{"context": {"encounter": [{"reference": "EpisodeOfCare/docref1"}]}}],
+        )
+        self.write_res("Encounter", [{"episodeOfCare": [{"reference": "EpisodeOfCare/enc1"}]}])
+        self.write_res("MedicationDispense", [{"context": {"reference": "EpisodeOfCare/meddisp1"}}])
+        self.set_basic_resource_route()
+        await self.cli("hydrate", self.folder, "--tasks=EpisodeOfCare")
+
+        self.assert_folder(
+            {
+                "EpisodeOfCare.referenced.ndjson.gz": [
+                    {"resourceType": "EpisodeOfCare", "id": "docref1"},
+                    {"resourceType": "EpisodeOfCare", "id": "enc1"},
+                    {"resourceType": "EpisodeOfCare", "id": "meddisp1"},
+                ],
+                "DocumentReference.ndjson.gz": None,
+                "Encounter.ndjson.gz": None,
+                "MedicationDispense.ndjson.gz": None,
+            }
+        )

--- a/tests/test_hydrate_org.py
+++ b/tests/test_hydrate_org.py
@@ -37,6 +37,10 @@ class HydrateOrganizationTests(utils.TestCase):
             ],
         )
         self.write_res(
+            resources.EPISODE_OF_CARE,
+            [{"managingOrganization": {"reference": "Organization/epofcare1"}}],
+        )
+        self.write_res(
             resources.IMMUNIZATION,
             [
                 {
@@ -124,6 +128,7 @@ class HydrateOrganizationTests(utils.TestCase):
                 "DiagnosticReport.ndjson.gz": None,
                 "DocumentReference.ndjson.gz": None,
                 "Encounter.ndjson.gz": None,
+                "EpisodeOfCare.ndjson.gz": None,
                 "Immunization.ndjson.gz": None,
                 "Location.ndjson.gz": None,
                 "MedicationDispense.ndjson.gz": None,
@@ -151,6 +156,7 @@ class HydrateOrganizationTests(utils.TestCase):
                     {"resourceType": "Organization", "id": "enc1"},
                     {"resourceType": "Organization", "id": "enc2"},
                     {"resourceType": "Organization", "id": "enc3"},
+                    {"resourceType": "Organization", "id": "epofcare1"},
                     {"resourceType": "Organization", "id": "imm1"},
                     {"resourceType": "Organization", "id": "imm2"},
                     {"resourceType": "Organization", "id": "imm3"},

--- a/tests/test_hydrate_pract.py
+++ b/tests/test_hydrate_pract.py
@@ -72,6 +72,13 @@ class HydratePractitionerTests(utils.TestCase):
             ],
         )
         self.write_res(
+            resources.EPISODE_OF_CARE,
+            [
+                {"careManager": {"reference": "Practitioner/epofcare1"}},
+                {"careManager": {"reference": "PractitionerRole/epofcare1"}},
+            ],
+        )
+        self.write_res(
             resources.IMMUNIZATION,
             [
                 {
@@ -197,6 +204,7 @@ class HydratePractitionerTests(utils.TestCase):
                 "DiagnosticReport.ndjson.gz": None,
                 "DocumentReference.ndjson.gz": None,
                 "Encounter.ndjson.gz": None,
+                "EpisodeOfCare.ndjson.gz": None,
                 "Immunization.ndjson.gz": None,
                 "Observation.ndjson.gz": None,
                 "MedicationDispense.ndjson.gz": None,
@@ -222,6 +230,7 @@ class HydratePractitionerTests(utils.TestCase):
                     {"resourceType": "Practitioner", "id": "doc2"},
                     {"resourceType": "Practitioner", "id": "doc3"},
                     {"resourceType": "Practitioner", "id": "enc1"},
+                    {"resourceType": "Practitioner", "id": "epofcare1"},
                     {"resourceType": "Practitioner", "id": "imm1"},
                     {"resourceType": "Practitioner", "id": "meddisp1"},
                     {"resourceType": "Practitioner", "id": "meddisp2"},
@@ -250,6 +259,7 @@ class HydratePractitionerTests(utils.TestCase):
                     {"resourceType": "PractitionerRole", "id": "doc2"},
                     {"resourceType": "PractitionerRole", "id": "doc3"},
                     {"resourceType": "PractitionerRole", "id": "enc1"},
+                    {"resourceType": "PractitionerRole", "id": "epofcare1"},
                     {"resourceType": "PractitionerRole", "id": "imm1"},
                     {"resourceType": "PractitionerRole", "id": "meddisp1"},
                     {"resourceType": "PractitionerRole", "id": "meddisp2"},

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -65,6 +65,7 @@ class TestCase(unittest.IsolatedAsyncioTestCase):
                         {"type": resources.DIAGNOSTIC_REPORT, "searchParam": [{"name": "issued"}]},
                         {"type": resources.DOCUMENT_REFERENCE, "searchParam": [{"name": "date"}]},
                         {"type": resources.ENCOUNTER},
+                        {"type": resources.EPISODE_OF_CARE},
                         {"type": resources.IMMUNIZATION},
                         {"type": resources.MEDICATION_DISPENSE},
                         {


### PR DESCRIPTION
EpisodeOfCare is a normal everyday patient-linked resource. And this commit adds it as such.

But it's also, on Epic alone, not easily crawlable, because Epic requires a specific type=system|code parameter too.

So I also added hydration support for EpisodeOfCare, mostly expecting them to come in via Encounters (but a few other resources link to them too).

Other changes:
- During this, I realized that the way we did hydration during an "export" call that used crawling could improve. Previously, we would hydrate after every resource crawled, as we went along. But I believe that approach was a leftover from when we marked resources as "done" after hydration. Now we mark them done before hydration, I believe to make it easier to retry failed hydration attempts. So all hydrations are always re-run anyway when you re-crawl (usually a no-op if you've already downloaded the resource). So now, to partially avoid an issue where we might hydrate EpisodeOfCare resources before crawling them directly, thus wasting time, I moved all the hydration to one big step at the end of a crawl, like we do for bulk exports. This simplified the code too.
- When deleting a bulk export, if we get a 404 from the server, it's likely because the server already cleaned it up for us (HAPI does this). So silently ignore 404s.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
