### PR TITLE
Improve progress output when redirected

### DIFF
--- a/smart_fetch/cli_utils.py
+++ b/smart_fetch/cli_utils.py
@@ -2,6 +2,7 @@ import argparse
 import itertools
 import os.path
 import sys
+import threading
 import tomllib
 import urllib.parse
 
@@ -342,18 +343,100 @@ def prepare(args) -> tuple[cfs.FhirClient, cfs.FhirClient]:
     return rest_client, bulk_client
 
 
-def make_progress_bar() -> rich.progress.Progress:
-    # The default columns use time remaining, which has felt inaccurate/less useful than a simple
-    # elapsed counter.
-    # - The estimation logic seems rough (often jumping time around).
-    # - For indeterminate bars, the estimate shows nothing.
-    columns = [
-        rich.progress.TextColumn("[progress.description]{task.description}"),
-        rich.progress.BarColumn(),
-        rich.progress.TaskProgressColumn(),
-        rich.progress.TimeElapsedColumn(),
-    ]
-    return rich.progress.Progress(*columns)
+class Progress(rich.progress.Progress):
+    """Progress display that remains useful when output is redirected."""
+
+    def __init__(self):
+        console = rich.get_console()
+        columns = [
+            rich.progress.TextColumn("[progress.description]{task.description}"),
+            rich.progress.BarColumn(),
+            rich.progress.TaskProgressColumn(),
+            rich.progress.TimeElapsedColumn(),
+        ]
+
+        self._thread = None
+        super().__init__(*columns, console=console)
+
+    def add_task(self, description: str, *args, **kwargs) -> rich.progress.TaskID:
+        task_id = super().add_task(description, *args, **kwargs)
+
+        self._stop_thread()
+        if not self.console.is_interactive:
+            self._thread = _RefreshThread(progress=self, task_id=task_id)
+            self._thread.start()
+
+        return task_id
+
+    def update(
+        self, task_id: rich.progress.TaskID, *args, completed=None, total=None, **kwargs
+    ) -> None:
+        super().update(task_id, *args, total=total, completed=completed, **kwargs)
+
+        if (
+            self._thread
+            and task_id == self._thread.task_id
+            and completed is not None
+            and total is not None
+            and completed == total
+        ):
+            self._stop_thread()
+
+    def stop(self, *args, **kwargs) -> None:
+        super().stop(*args, **kwargs)
+        self._stop_thread()
+
+    def _stop_thread(self) -> None:
+        if self._thread:
+            self._thread.stop()
+            self._thread = None
+
+
+def make_progress_bar() -> Progress:
+    return Progress()
+
+
+class _RefreshThread(threading.Thread):
+    def __init__(self, progress: Progress, task_id: rich.progress.TaskID) -> None:
+        self.progress = progress
+        self.task_id = task_id
+        self.done = threading.Event()
+        super().__init__(daemon=True)
+
+    def _find_task(self) -> rich.progress.Task | None:
+        for task in self.progress.tasks:
+            if task.id == self.task_id:
+                return task
+        return None  # pragma: no cover
+
+    def stop(self) -> None:
+        self.done.set()
+
+    def _print(self) -> None:
+        task = self._find_task()
+        if not task:
+            return  # pragma: no cover
+
+        elapsed = human_time_offset(int(task.elapsed))
+        if elapsed == "0s":
+            rich.print(f"{task.description}…")
+        elif task.total:
+            rich.print(f"{task.description}… ({task.percentage:.0f}%, {elapsed} so far)")
+        else:
+            rich.print(f"{task.description}… ({elapsed} so far)")
+
+    def _delay(self) -> int:
+        task = self._find_task()
+        if not task or task.elapsed < 60 * 60:
+            return 60
+        return 120
+
+    def run(self) -> None:
+        self._print()
+        while not self.done.wait(self._delay()):
+            if self.done.is_set():
+                break  # pragma: no cover
+            self._print()
 
 
 def _pretty_float(num: float, precision: int = 1) -> str:

--- a/smart_fetch/iter_utils.py
+++ b/smart_fetch/iter_utils.py
@@ -123,9 +123,9 @@ class ResourceProcessor:
         for res_type, sources in self.sources.items():
             timestamp = timing.now()
 
-            with cli_utils.make_progress_bar() as progress:
+            with cli_utils.Progress() as progress:
                 res_total = sum(src.total for src in sources)
-                task = progress.add_task(f"{self._desc} {res_type}s…", total=res_total)
+                task = progress.add_task(f"{self._desc} {res_type}s", total=res_total)
 
                 for source in sources:
                     writer = ndjson.NdjsonWriter(source.output_file, append=self._append)
@@ -151,4 +151,4 @@ class ResourceProcessor:
         item: Item,
     ) -> None:
         await self._callback(res_type, writer, item)
-        progress.update(task, advance=1)
+        progress.advance(task)

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -8,6 +8,11 @@ from smart_fetch import cli_utils, iter_utils
 
 
 class ProgressTests(unittest.TestCase):
+    @mock.patch("smart_fetch.cli_utils.Progress")
+    def test_make_progress_bar_returns_progress(self, mock_progress):
+        self.assertIs(cli_utils.make_progress_bar(), mock_progress.return_value)
+        mock_progress.assert_called_once_with()
+
     @mock.patch("smart_fetch.cli_utils._RefreshThread")
     @mock.patch("rich.get_console")
     def test_redirected_output_starts_refresh_thread(self, mock_get_console, mock_thread):
@@ -91,6 +96,25 @@ class ProgressTests(unittest.TestCase):
 
 
 class ResourceProcessorTests(unittest.IsolatedAsyncioTestCase):
+    @mock.patch("smart_fetch.iter_utils.peek_ahead_processor", new_callable=mock.AsyncMock)
+    @mock.patch("smart_fetch.iter_utils.ndjson.NdjsonWriter")
+    @mock.patch("smart_fetch.iter_utils.cli_utils.Progress")
+    async def test_run_uses_redirected_progress(
+        self, mock_progress_cls, mock_writer_cls, mock_peek_ahead
+    ):
+        progress = mock_progress_cls.return_value.__enter__.return_value
+        progress.add_task.return_value = 7
+        processor = iter_utils.ResourceProcessor(".", "Crawling", mock.AsyncMock())
+        processor.add_source("Patient", mock.Mock(), total=3, output_file="patients.ndjson")
+
+        await processor.run()
+
+        mock_progress_cls.assert_called_once_with()
+        progress.add_task.assert_called_once_with("Crawling Patients", total=3)
+        mock_writer_cls.assert_called_once()
+        mock_peek_ahead.assert_awaited_once()
+        self.assertEqual(processor.sources, {})
+
     async def test_processed_item_advances_progress(self):
         callback = mock.AsyncMock()
         processor = iter_utils.ResourceProcessor(".", "Crawling", callback)

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,104 @@
+import io
+import unittest
+from unittest import mock
+
+import rich.console
+
+from smart_fetch import cli_utils, iter_utils
+
+
+class ProgressTests(unittest.TestCase):
+    @mock.patch("smart_fetch.cli_utils._RefreshThread")
+    @mock.patch("rich.get_console")
+    def test_redirected_output_starts_refresh_thread(self, mock_get_console, mock_thread):
+        console = rich.console.Console(file=io.StringIO(), force_terminal=False)
+        mock_get_console.return_value = console
+
+        progress = cli_utils.Progress()
+        task_id = progress.add_task("Crawling Patients", total=4)
+
+        mock_thread.assert_called_once_with(progress=progress, task_id=task_id)
+        mock_thread.return_value.start.assert_called_once_with()
+        mock_thread.return_value.task_id = task_id
+
+        progress.update(task_id, advance=1)
+        mock_thread.return_value.stop.assert_not_called()
+
+        progress.update(task_id, completed=4, total=4)
+        mock_thread.return_value.stop.assert_called_once_with()
+        self.assertIsNone(progress._thread)
+        progress.stop()
+
+    @mock.patch("smart_fetch.cli_utils._RefreshThread")
+    @mock.patch("rich.get_console")
+    def test_interactive_output_does_not_start_refresh_thread(self, mock_get_console, mock_thread):
+        console = rich.console.Console(file=io.StringIO(), force_terminal=True)
+        mock_get_console.return_value = console
+
+        progress = cli_utils.Progress()
+        progress.add_task("Crawling Patients", total=4)
+
+        mock_thread.assert_not_called()
+        progress.stop()
+
+    @mock.patch("rich.print")
+    @mock.patch("rich.get_console")
+    def test_refresh_message_includes_progress_and_elapsed_time(self, mock_get_console, mock_print):
+        console = rich.console.Console(file=io.StringIO(), force_terminal=True)
+        mock_get_console.return_value = console
+        progress = cli_utils.Progress()
+        task_id = progress.add_task("Crawling Patients", total=4, completed=1)
+        task = progress.tasks[0]
+        refresh = cli_utils._RefreshThread(progress, task_id)
+
+        refresh._print()
+        mock_print.assert_called_once_with("Crawling Patients…")
+
+        mock_print.reset_mock()
+        task.start_time -= 90
+        refresh._print()
+        mock_print.assert_called_once_with("Crawling Patients… (25%, 1.5m so far)")
+
+        mock_print.reset_mock()
+        task.total = None
+        refresh._print()
+        mock_print.assert_called_once_with("Crawling Patients… (1.5m so far)")
+
+        self.assertEqual(refresh._delay(), 60)
+        task.start_time -= 60 * 60
+        self.assertEqual(refresh._delay(), 120)
+        refresh.stop()
+        self.assertTrue(refresh.done.is_set())
+        progress.stop()
+
+    @mock.patch("rich.get_console")
+    def test_refresh_thread_prints_before_waiting(self, mock_get_console):
+        console = rich.console.Console(file=io.StringIO(), force_terminal=True)
+        mock_get_console.return_value = console
+        progress = cli_utils.Progress()
+        task_id = progress.add_task("Crawling Patients", total=4)
+        refresh = cli_utils._RefreshThread(progress, task_id)
+        refresh.done = mock.Mock()
+        refresh.done.wait.side_effect = [False, True]
+        refresh.done.is_set.return_value = False
+
+        with mock.patch.object(refresh, "_print") as mock_print:
+            refresh.run()
+
+        self.assertEqual(mock_print.call_count, 2)
+        self.assertEqual(refresh.done.wait.call_args_list, [mock.call(60), mock.call(60)])
+        progress.stop()
+
+
+class ResourceProcessorTests(unittest.IsolatedAsyncioTestCase):
+    async def test_processed_item_advances_progress(self):
+        callback = mock.AsyncMock()
+        processor = iter_utils.ResourceProcessor(".", "Crawling", callback)
+        progress = mock.Mock()
+        writer = mock.Mock()
+        item = {"id": "example"}
+
+        await processor._process_wrapper(writer, "Patient", progress, 3, item)
+
+        callback.assert_awaited_once_with("Patient", writer, item)
+        progress.advance.assert_called_once_with(3)


### PR DESCRIPTION
## Summary
- keep Rich progress bars for interactive terminals
- emit immediate plain-text status and periodic percentage/elapsed updates when output is redirected
- slow log updates to every two minutes after the first hour

## Tests
- `python -m pytest -q tests/test_feedback.py`
- `python -m ruff check .`
- `python -m ruff format --check .`

Fixes #60

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added